### PR TITLE
fix: Fixes scoped package publishing. Adds bin script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gleanwork/mcp-server",
   "version": "0.0.1",
-  "private": true,
   "description": "MCP server for Glean API integration",
   "keywords": [
     "mcp",
@@ -15,6 +14,9 @@
   "license": "MIT",
   "author": "Steve Calvert <steve.calvert@glean.com>",
   "type": "module",
+  "bin": {
+    "glean-mcp-server": "build/index.js"
+  },
   "main": "./build/index.js",
   "files": [
     "build/lib/**/*",
@@ -64,7 +66,8 @@
     "pnpm": "10.6.2"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org"
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
   },
   "release-it": {
     "plugins": {
@@ -79,7 +82,6 @@
     "github": {
       "release": true,
       "tokenRef": "GITHUB_AUTH"
-    },
-    "npm": false
+    }
   }
 }


### PR DESCRIPTION
# Summary

In order to publish a scoped package, you need to set the `package.json`'s `publishConfig.access` to "public". In addition, this change adds a bin script to the repository, which allows for correct invocation of the MCP server via an MCP client (MCP clients use `npx -y <packageName>` to invoke the server, and that requires a package bin to work correctly.
