### PR TITLE
fix: Adds defaults for search.pageSize (otherwise no results are returned)

### DIFF
--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -195,7 +195,7 @@ export const SearchSchema = z.object({
     .number()
     .optional()
     .describe('Maximum characters for snippets'),
-  pageSize: z.number().optional().describe('Number of results to return'),
+  pageSize: z.number().default(10).describe('Number of results to return'),
   timestamp: z
     .string()
     .optional()


### PR DESCRIPTION
# Summary

Without a default `pageSize` parameters that's non-zero, the `/search` endpoint will return 0 results. This change applies a default pageSize of 10. This value was deemed a good compromise to give enough results without being overly verbose.

The reason adding it to the zod schemas works is because we're using `schema.parse` to validate the inbound params, and zod will "fill in" missing defaults during parse.

