### PR TITLE
Fix schema validation errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
   "license": "MIT",
   "author": "Steve Calvert <steve.calvert@glean.com>",
   "type": "module",
+  "main": "./build/index.js",
   "bin": {
     "glean-mcp-server": "build/index.js"
   },
-  "main": "./build/index.js",
   "files": [
     "build/common/**/*",
     "build/tools/**/*",
@@ -26,14 +26,14 @@
   ],
   "scripts": {
     "build": "tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\"",
-    "watch": "tsc -w",
     "format": "prettier src/**/*.ts -w",
     "inspector": "npx @modelcontextprotocol/inspector build/index.js",
     "lint": "eslint --ext ts,js --fix src",
     "prepare": "pnpm run build",
     "release": "release-it",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.7.0",
@@ -67,8 +67,13 @@
     "pnpm": "10.6.2"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org",
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
   },
   "release-it": {
     "plugins": {

--- a/src/test/tools/schemas.test.ts
+++ b/src/test/tools/schemas.test.ts
@@ -98,7 +98,34 @@ describe('Schema to JSON Schema conversion', () => {
                                   "type": "string",
                                 },
                                 "containerDocument": {
+                                  "additionalProperties": false,
                                   "description": "The container document",
+                                  "properties": {
+                                    "datasource": {
+                                      "description": "The app or other repository type from which the document was extracted",
+                                      "type": "string",
+                                    },
+                                    "docType": {
+                                      "description": "The datasource-specific type of the document",
+                                      "type": "string",
+                                    },
+                                    "id": {
+                                      "description": "The Glean Document ID",
+                                      "type": "string",
+                                    },
+                                    "title": {
+                                      "description": "The title of the document",
+                                      "type": "string",
+                                    },
+                                    "url": {
+                                      "description": "A permalink for the document",
+                                      "type": "string",
+                                    },
+                                  },
+                                  "required": [
+                                    "id",
+                                  ],
+                                  "type": "object",
                                 },
                                 "content": {
                                   "additionalProperties": false,
@@ -137,7 +164,34 @@ describe('Schema to JSON Schema conversion', () => {
                                   "type": "object",
                                 },
                                 "parentDocument": {
+                                  "additionalProperties": false,
                                   "description": "The parent document",
+                                  "properties": {
+                                    "datasource": {
+                                      "description": "The app or other repository type from which the document was extracted",
+                                      "type": "string",
+                                    },
+                                    "docType": {
+                                      "description": "The datasource-specific type of the document",
+                                      "type": "string",
+                                    },
+                                    "id": {
+                                      "description": "The Glean Document ID",
+                                      "type": "string",
+                                    },
+                                    "title": {
+                                      "description": "The title of the document",
+                                      "type": "string",
+                                    },
+                                    "url": {
+                                      "description": "A permalink for the document",
+                                      "type": "string",
+                                    },
+                                  },
+                                  "required": [
+                                    "id",
+                                  ],
+                                  "type": "object",
                                 },
                                 "sections": {
                                   "description": "A list of content sub-sections in the document",
@@ -254,7 +308,34 @@ describe('Schema to JSON Schema conversion', () => {
                                       "type": "string",
                                     },
                                     "containerDocument": {
+                                      "additionalProperties": false,
                                       "description": "The container document",
+                                      "properties": {
+                                        "datasource": {
+                                          "description": "The app or other repository type from which the document was extracted",
+                                          "type": "string",
+                                        },
+                                        "docType": {
+                                          "description": "The datasource-specific type of the document",
+                                          "type": "string",
+                                        },
+                                        "id": {
+                                          "description": "The Glean Document ID",
+                                          "type": "string",
+                                        },
+                                        "title": {
+                                          "description": "The title of the document",
+                                          "type": "string",
+                                        },
+                                        "url": {
+                                          "description": "A permalink for the document",
+                                          "type": "string",
+                                        },
+                                      },
+                                      "required": [
+                                        "id",
+                                      ],
+                                      "type": "object",
                                     },
                                     "content": {
                                       "additionalProperties": false,
@@ -293,7 +374,34 @@ describe('Schema to JSON Schema conversion', () => {
                                       "type": "object",
                                     },
                                     "parentDocument": {
+                                      "additionalProperties": false,
                                       "description": "The parent document",
+                                      "properties": {
+                                        "datasource": {
+                                          "description": "The app or other repository type from which the document was extracted",
+                                          "type": "string",
+                                        },
+                                        "docType": {
+                                          "description": "The datasource-specific type of the document",
+                                          "type": "string",
+                                        },
+                                        "id": {
+                                          "description": "The Glean Document ID",
+                                          "type": "string",
+                                        },
+                                        "title": {
+                                          "description": "The title of the document",
+                                          "type": "string",
+                                        },
+                                        "url": {
+                                          "description": "A permalink for the document",
+                                          "type": "string",
+                                        },
+                                      },
+                                      "required": [
+                                        "id",
+                                      ],
+                                      "type": "object",
                                     },
                                     "sections": {
                                       "description": "A list of content sub-sections in the document",
@@ -391,7 +499,34 @@ describe('Schema to JSON Schema conversion', () => {
                                                   "type": "string",
                                                 },
                                                 "containerDocument": {
+                                                  "additionalProperties": false,
                                                   "description": "The container document",
+                                                  "properties": {
+                                                    "datasource": {
+                                                      "description": "The app or other repository type from which the document was extracted",
+                                                      "type": "string",
+                                                    },
+                                                    "docType": {
+                                                      "description": "The datasource-specific type of the document",
+                                                      "type": "string",
+                                                    },
+                                                    "id": {
+                                                      "description": "The Glean Document ID",
+                                                      "type": "string",
+                                                    },
+                                                    "title": {
+                                                      "description": "The title of the document",
+                                                      "type": "string",
+                                                    },
+                                                    "url": {
+                                                      "description": "A permalink for the document",
+                                                      "type": "string",
+                                                    },
+                                                  },
+                                                  "required": [
+                                                    "id",
+                                                  ],
+                                                  "type": "object",
                                                 },
                                                 "content": {
                                                   "additionalProperties": false,
@@ -430,7 +565,34 @@ describe('Schema to JSON Schema conversion', () => {
                                                   "type": "object",
                                                 },
                                                 "parentDocument": {
+                                                  "additionalProperties": false,
                                                   "description": "The parent document",
+                                                  "properties": {
+                                                    "datasource": {
+                                                      "description": "The app or other repository type from which the document was extracted",
+                                                      "type": "string",
+                                                    },
+                                                    "docType": {
+                                                      "description": "The datasource-specific type of the document",
+                                                      "type": "string",
+                                                    },
+                                                    "id": {
+                                                      "description": "The Glean Document ID",
+                                                      "type": "string",
+                                                    },
+                                                    "title": {
+                                                      "description": "The title of the document",
+                                                      "type": "string",
+                                                    },
+                                                    "url": {
+                                                      "description": "A permalink for the document",
+                                                      "type": "string",
+                                                    },
+                                                  },
+                                                  "required": [
+                                                    "id",
+                                                  ],
+                                                  "type": "object",
                                                 },
                                                 "sections": {
                                                   "description": "A list of content sub-sections in the document",
@@ -1199,7 +1361,34 @@ describe('Schema to JSON Schema conversion', () => {
                                               "type": "string",
                                             },
                                             "containerDocument": {
+                                              "additionalProperties": false,
                                               "description": "The container document",
+                                              "properties": {
+                                                "datasource": {
+                                                  "description": "The app or other repository type from which the document was extracted",
+                                                  "type": "string",
+                                                },
+                                                "docType": {
+                                                  "description": "The datasource-specific type of the document",
+                                                  "type": "string",
+                                                },
+                                                "id": {
+                                                  "description": "The Glean Document ID",
+                                                  "type": "string",
+                                                },
+                                                "title": {
+                                                  "description": "The title of the document",
+                                                  "type": "string",
+                                                },
+                                                "url": {
+                                                  "description": "A permalink for the document",
+                                                  "type": "string",
+                                                },
+                                              },
+                                              "required": [
+                                                "id",
+                                              ],
+                                              "type": "object",
                                             },
                                             "content": {
                                               "additionalProperties": false,
@@ -1238,7 +1427,34 @@ describe('Schema to JSON Schema conversion', () => {
                                               "type": "object",
                                             },
                                             "parentDocument": {
+                                              "additionalProperties": false,
                                               "description": "The parent document",
+                                              "properties": {
+                                                "datasource": {
+                                                  "description": "The app or other repository type from which the document was extracted",
+                                                  "type": "string",
+                                                },
+                                                "docType": {
+                                                  "description": "The datasource-specific type of the document",
+                                                  "type": "string",
+                                                },
+                                                "id": {
+                                                  "description": "The Glean Document ID",
+                                                  "type": "string",
+                                                },
+                                                "title": {
+                                                  "description": "The title of the document",
+                                                  "type": "string",
+                                                },
+                                                "url": {
+                                                  "description": "A permalink for the document",
+                                                  "type": "string",
+                                                },
+                                              },
+                                              "required": [
+                                                "id",
+                                              ],
+                                              "type": "object",
                                             },
                                             "sections": {
                                               "description": "A list of content sub-sections in the document",
@@ -1460,7 +1676,34 @@ describe('Schema to JSON Schema conversion', () => {
                                       "type": "string",
                                     },
                                     "containerDocument": {
+                                      "additionalProperties": false,
                                       "description": "The container document",
+                                      "properties": {
+                                        "datasource": {
+                                          "description": "The app or other repository type from which the document was extracted",
+                                          "type": "string",
+                                        },
+                                        "docType": {
+                                          "description": "The datasource-specific type of the document",
+                                          "type": "string",
+                                        },
+                                        "id": {
+                                          "description": "The Glean Document ID",
+                                          "type": "string",
+                                        },
+                                        "title": {
+                                          "description": "The title of the document",
+                                          "type": "string",
+                                        },
+                                        "url": {
+                                          "description": "A permalink for the document",
+                                          "type": "string",
+                                        },
+                                      },
+                                      "required": [
+                                        "id",
+                                      ],
+                                      "type": "object",
                                     },
                                     "content": {
                                       "additionalProperties": false,
@@ -1499,7 +1742,34 @@ describe('Schema to JSON Schema conversion', () => {
                                       "type": "object",
                                     },
                                     "parentDocument": {
+                                      "additionalProperties": false,
                                       "description": "The parent document",
+                                      "properties": {
+                                        "datasource": {
+                                          "description": "The app or other repository type from which the document was extracted",
+                                          "type": "string",
+                                        },
+                                        "docType": {
+                                          "description": "The datasource-specific type of the document",
+                                          "type": "string",
+                                        },
+                                        "id": {
+                                          "description": "The Glean Document ID",
+                                          "type": "string",
+                                        },
+                                        "title": {
+                                          "description": "The title of the document",
+                                          "type": "string",
+                                        },
+                                        "url": {
+                                          "description": "A permalink for the document",
+                                          "type": "string",
+                                        },
+                                      },
+                                      "required": [
+                                        "id",
+                                      ],
+                                      "type": "object",
                                     },
                                     "sections": {
                                       "description": "A list of content sub-sections in the document",
@@ -1582,7 +1852,34 @@ describe('Schema to JSON Schema conversion', () => {
                                                   "type": "string",
                                                 },
                                                 "containerDocument": {
+                                                  "additionalProperties": false,
                                                   "description": "The container document",
+                                                  "properties": {
+                                                    "datasource": {
+                                                      "description": "The app or other repository type from which the document was extracted",
+                                                      "type": "string",
+                                                    },
+                                                    "docType": {
+                                                      "description": "The datasource-specific type of the document",
+                                                      "type": "string",
+                                                    },
+                                                    "id": {
+                                                      "description": "The Glean Document ID",
+                                                      "type": "string",
+                                                    },
+                                                    "title": {
+                                                      "description": "The title of the document",
+                                                      "type": "string",
+                                                    },
+                                                    "url": {
+                                                      "description": "A permalink for the document",
+                                                      "type": "string",
+                                                    },
+                                                  },
+                                                  "required": [
+                                                    "id",
+                                                  ],
+                                                  "type": "object",
                                                 },
                                                 "content": {
                                                   "additionalProperties": false,
@@ -1621,7 +1918,34 @@ describe('Schema to JSON Schema conversion', () => {
                                                   "type": "object",
                                                 },
                                                 "parentDocument": {
+                                                  "additionalProperties": false,
                                                   "description": "The parent document",
+                                                  "properties": {
+                                                    "datasource": {
+                                                      "description": "The app or other repository type from which the document was extracted",
+                                                      "type": "string",
+                                                    },
+                                                    "docType": {
+                                                      "description": "The datasource-specific type of the document",
+                                                      "type": "string",
+                                                    },
+                                                    "id": {
+                                                      "description": "The Glean Document ID",
+                                                      "type": "string",
+                                                    },
+                                                    "title": {
+                                                      "description": "The title of the document",
+                                                      "type": "string",
+                                                    },
+                                                    "url": {
+                                                      "description": "A permalink for the document",
+                                                      "type": "string",
+                                                    },
+                                                  },
+                                                  "required": [
+                                                    "id",
+                                                  ],
+                                                  "type": "object",
                                                 },
                                                 "sections": {
                                                   "description": "A list of content sub-sections in the document",

--- a/src/test/tools/schemas.test.ts
+++ b/src/test/tools/schemas.test.ts
@@ -1,0 +1,1812 @@
+import { describe, it, expect } from 'vitest';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+import { SearchSchema } from '../../tools/search.js';
+import { ChatSchema } from '../../tools/chat.js';
+
+describe('Schema to JSON Schema conversion', () => {
+  it('should convert SearchSchema to JSON Schema format', () => {
+    const jsonSchema = zodToJsonSchema(SearchSchema, {
+      name: 'SearchSchema',
+      $refStrategy: 'none',
+    });
+
+    expect(jsonSchema).toMatchInlineSnapshot(`
+      {
+        "$ref": "#/definitions/SearchSchema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "definitions": {
+          "SearchSchema": {
+            "additionalProperties": false,
+            "properties": {
+              "cursor": {
+                "description": "Pagination cursor for position in overall results",
+                "type": "string",
+              },
+              "disableSpellcheck": {
+                "description": "Whether to disable spellcheck",
+                "type": "boolean",
+              },
+              "inputDetails": {
+                "additionalProperties": false,
+                "description": "Additional metadata about the search input",
+                "properties": {
+                  "hasCopyPaste": {
+                    "type": "boolean",
+                  },
+                },
+                "type": "object",
+              },
+              "maxSnippetSize": {
+                "description": "Maximum characters for snippets",
+                "type": "number",
+              },
+              "pageSize": {
+                "default": 10,
+                "description": "Number of results to return",
+                "type": "number",
+              },
+              "people": {
+                "description": "People associated with the search request",
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "email": {
+                      "description": "The email address of the person",
+                      "type": "string",
+                    },
+                    "metadata": {
+                      "additionalProperties": {
+                        "type": "string",
+                      },
+                      "description": "Additional metadata about the person",
+                      "type": "object",
+                    },
+                    "name": {
+                      "description": "The display name",
+                      "type": "string",
+                    },
+                    "obfuscatedId": {
+                      "description": "An opaque identifier that can be used to request metadata for a Person",
+                      "type": "string",
+                    },
+                    "relatedDocuments": {
+                      "description": "A list of documents related to this person",
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "associatedEntityId": {
+                            "description": "Which entity in the response that this entity relates to.",
+                            "type": "string",
+                          },
+                          "documents": {
+                            "description": "A truncated list of documents with this relation. TO BE DEPRECATED.",
+                            "items": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "connectorType": {
+                                  "description": "The type of connector used to extract the document",
+                                  "enum": [
+                                    "API_CRAWL",
+                                    "BROWSER_CRAWL",
+                                    "BROWSER_HISTORY",
+                                    "BUILTIN",
+                                    "FEDERATED_SEARCH",
+                                    "PUSH_API",
+                                    "WEB_CRAWL",
+                                    "NATIVE_HISTORY",
+                                  ],
+                                  "type": "string",
+                                },
+                                "containerDocument": {
+                                  "description": "The container document",
+                                },
+                                "content": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "fullTextList": {
+                                      "description": "The plaintext content of the document",
+                                      "items": {
+                                        "type": "string",
+                                      },
+                                      "type": "array",
+                                    },
+                                  },
+                                  "type": "object",
+                                },
+                                "datasource": {
+                                  "description": "The app or other repository type from which the document was extracted",
+                                  "type": "string",
+                                },
+                                "docType": {
+                                  "description": "The datasource-specific type of the document",
+                                  "type": "string",
+                                },
+                                "id": {
+                                  "description": "The Glean Document ID",
+                                  "type": "string",
+                                },
+                                "metadata": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "customData": {
+                                      "additionalProperties": {},
+                                      "description": "Custom metadata fields",
+                                      "type": "object",
+                                    },
+                                  },
+                                  "type": "object",
+                                },
+                                "parentDocument": {
+                                  "description": "The parent document",
+                                },
+                                "sections": {
+                                  "description": "A list of content sub-sections in the document",
+                                  "items": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "content": {
+                                        "description": "Section content",
+                                        "type": "string",
+                                      },
+                                      "endIndex": {
+                                        "description": "End index of section in document",
+                                        "type": "number",
+                                      },
+                                      "level": {
+                                        "description": "Heading level of the section",
+                                        "type": "number",
+                                      },
+                                      "startIndex": {
+                                        "description": "Start index of section in document",
+                                        "type": "number",
+                                      },
+                                      "title": {
+                                        "description": "Section title",
+                                        "type": "string",
+                                      },
+                                      "type": {
+                                        "description": "Type of section",
+                                        "type": "string",
+                                      },
+                                    },
+                                    "type": "object",
+                                  },
+                                  "type": "array",
+                                },
+                                "title": {
+                                  "description": "The title of the document",
+                                  "type": "string",
+                                },
+                                "url": {
+                                  "description": "A permalink for the document",
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "id",
+                              ],
+                              "type": "object",
+                            },
+                            "type": "array",
+                          },
+                          "querySuggestion": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "datasource": {
+                                "description": "The datasource associated with the suggestion",
+                                "type": "string",
+                              },
+                              "label": {
+                                "description": "User-facing description of the suggestion",
+                                "type": "string",
+                              },
+                              "query": {
+                                "description": "The suggested query",
+                                "type": "string",
+                              },
+                            },
+                            "required": [
+                              "query",
+                            ],
+                            "type": "object",
+                          },
+                          "relation": {
+                            "description": "How this document relates to the including entity.",
+                            "enum": [
+                              "ATTACHMENT",
+                              "CANONICAL",
+                              "CASE",
+                              "CONTACT",
+                              "CONVERSATION_MESSAGES",
+                              "EXPERT",
+                              "FROM",
+                              "HIGHLIGHT",
+                              "OPPORTUNITY",
+                              "RECENT",
+                              "SOURCE",
+                              "TICKET",
+                              "TRANSCRIPT",
+                              "WITH",
+                            ],
+                            "type": "string",
+                          },
+                          "results": {
+                            "description": "A truncated list of documents associated with this relation.",
+                            "items": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "document": {
+                                  "additionalProperties": false,
+                                  "description": "The document this result represents",
+                                  "properties": {
+                                    "connectorType": {
+                                      "description": "The type of connector used to extract the document",
+                                      "enum": [
+                                        "API_CRAWL",
+                                        "BROWSER_CRAWL",
+                                        "BROWSER_HISTORY",
+                                        "BUILTIN",
+                                        "FEDERATED_SEARCH",
+                                        "PUSH_API",
+                                        "WEB_CRAWL",
+                                        "NATIVE_HISTORY",
+                                      ],
+                                      "type": "string",
+                                    },
+                                    "containerDocument": {
+                                      "description": "The container document",
+                                    },
+                                    "content": {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "fullTextList": {
+                                          "description": "The plaintext content of the document",
+                                          "items": {
+                                            "type": "string",
+                                          },
+                                          "type": "array",
+                                        },
+                                      },
+                                      "type": "object",
+                                    },
+                                    "datasource": {
+                                      "description": "The app or other repository type from which the document was extracted",
+                                      "type": "string",
+                                    },
+                                    "docType": {
+                                      "description": "The datasource-specific type of the document",
+                                      "type": "string",
+                                    },
+                                    "id": {
+                                      "description": "The Glean Document ID",
+                                      "type": "string",
+                                    },
+                                    "metadata": {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "customData": {
+                                          "additionalProperties": {},
+                                          "description": "Custom metadata fields",
+                                          "type": "object",
+                                        },
+                                      },
+                                      "type": "object",
+                                    },
+                                    "parentDocument": {
+                                      "description": "The parent document",
+                                    },
+                                    "sections": {
+                                      "description": "A list of content sub-sections in the document",
+                                      "items": {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "content": {
+                                            "description": "Section content",
+                                            "type": "string",
+                                          },
+                                          "endIndex": {
+                                            "description": "End index of section in document",
+                                            "type": "number",
+                                          },
+                                          "level": {
+                                            "description": "Heading level of the section",
+                                            "type": "number",
+                                          },
+                                          "startIndex": {
+                                            "description": "Start index of section in document",
+                                            "type": "number",
+                                          },
+                                          "title": {
+                                            "description": "Section title",
+                                            "type": "string",
+                                          },
+                                          "type": {
+                                            "description": "Type of section",
+                                            "type": "string",
+                                          },
+                                        },
+                                        "type": "object",
+                                      },
+                                      "type": "array",
+                                    },
+                                    "title": {
+                                      "description": "The title of the document",
+                                      "type": "string",
+                                    },
+                                    "url": {
+                                      "description": "A permalink for the document",
+                                      "type": "string",
+                                    },
+                                  },
+                                  "required": [
+                                    "id",
+                                  ],
+                                  "type": "object",
+                                },
+                                "fullText": {
+                                  "description": "The full body text of the result",
+                                  "type": "string",
+                                },
+                                "fullTextList": {
+                                  "description": "The full body text split by lines",
+                                  "items": {
+                                    "type": "string",
+                                  },
+                                  "type": "array",
+                                },
+                                "nativeAppUrl": {
+                                  "description": "Deep link into datasource native application",
+                                  "type": "string",
+                                },
+                                "snippets": {
+                                  "description": "Text content from the result document",
+                                  "items": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "mimeType": {
+                                        "description": "The mime type of the snippets",
+                                        "type": "string",
+                                      },
+                                      "ranges": {
+                                        "description": "The bolded ranges within text",
+                                        "items": {
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "document": {
+                                              "additionalProperties": false,
+                                              "description": "Referenced document",
+                                              "properties": {
+                                                "connectorType": {
+                                                  "description": "The type of connector used to extract the document",
+                                                  "enum": [
+                                                    "API_CRAWL",
+                                                    "BROWSER_CRAWL",
+                                                    "BROWSER_HISTORY",
+                                                    "BUILTIN",
+                                                    "FEDERATED_SEARCH",
+                                                    "PUSH_API",
+                                                    "WEB_CRAWL",
+                                                    "NATIVE_HISTORY",
+                                                  ],
+                                                  "type": "string",
+                                                },
+                                                "containerDocument": {
+                                                  "description": "The container document",
+                                                },
+                                                "content": {
+                                                  "additionalProperties": false,
+                                                  "properties": {
+                                                    "fullTextList": {
+                                                      "description": "The plaintext content of the document",
+                                                      "items": {
+                                                        "type": "string",
+                                                      },
+                                                      "type": "array",
+                                                    },
+                                                  },
+                                                  "type": "object",
+                                                },
+                                                "datasource": {
+                                                  "description": "The app or other repository type from which the document was extracted",
+                                                  "type": "string",
+                                                },
+                                                "docType": {
+                                                  "description": "The datasource-specific type of the document",
+                                                  "type": "string",
+                                                },
+                                                "id": {
+                                                  "description": "The Glean Document ID",
+                                                  "type": "string",
+                                                },
+                                                "metadata": {
+                                                  "additionalProperties": false,
+                                                  "properties": {
+                                                    "customData": {
+                                                      "additionalProperties": {},
+                                                      "description": "Custom metadata fields",
+                                                      "type": "object",
+                                                    },
+                                                  },
+                                                  "type": "object",
+                                                },
+                                                "parentDocument": {
+                                                  "description": "The parent document",
+                                                },
+                                                "sections": {
+                                                  "description": "A list of content sub-sections in the document",
+                                                  "items": {
+                                                    "additionalProperties": false,
+                                                    "properties": {
+                                                      "content": {
+                                                        "description": "Section content",
+                                                        "type": "string",
+                                                      },
+                                                      "endIndex": {
+                                                        "description": "End index of section in document",
+                                                        "type": "number",
+                                                      },
+                                                      "level": {
+                                                        "description": "Heading level of the section",
+                                                        "type": "number",
+                                                      },
+                                                      "startIndex": {
+                                                        "description": "Start index of section in document",
+                                                        "type": "number",
+                                                      },
+                                                      "title": {
+                                                        "description": "Section title",
+                                                        "type": "string",
+                                                      },
+                                                      "type": {
+                                                        "description": "Type of section",
+                                                        "type": "string",
+                                                      },
+                                                    },
+                                                    "type": "object",
+                                                  },
+                                                  "type": "array",
+                                                },
+                                                "title": {
+                                                  "description": "The title of the document",
+                                                  "type": "string",
+                                                },
+                                                "url": {
+                                                  "description": "A permalink for the document",
+                                                  "type": "string",
+                                                },
+                                              },
+                                              "required": [
+                                                "id",
+                                              ],
+                                              "type": "object",
+                                            },
+                                            "endIndex": {
+                                              "description": "Exclusive end index of the range",
+                                              "type": "number",
+                                            },
+                                            "startIndex": {
+                                              "description": "Inclusive start index of the range",
+                                              "type": "number",
+                                            },
+                                            "type": {
+                                              "description": "Type of formatting to apply",
+                                              "enum": [
+                                                "BOLD",
+                                                "CITATION",
+                                                "LINK",
+                                              ],
+                                              "type": "string",
+                                            },
+                                            "url": {
+                                              "description": "URL associated with the range",
+                                              "type": "string",
+                                            },
+                                          },
+                                          "required": [
+                                            "startIndex",
+                                            "endIndex",
+                                            "type",
+                                          ],
+                                          "type": "object",
+                                        },
+                                        "type": "array",
+                                      },
+                                      "snippet": {
+                                        "description": "A matching snippet from the document with query term matches",
+                                        "type": "string",
+                                      },
+                                      "snippetTextOrdering": {
+                                        "description": "Used for sorting based off snippet location",
+                                        "type": "number",
+                                      },
+                                      "text": {
+                                        "description": "A matching snippet from the document with no highlights",
+                                        "type": "string",
+                                      },
+                                      "url": {
+                                        "description": "URL that links to the position of the snippet text",
+                                        "type": "string",
+                                      },
+                                    },
+                                    "required": [
+                                      "snippet",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  "type": "array",
+                                },
+                                "title": {
+                                  "description": "Title of the search result",
+                                  "type": "string",
+                                },
+                                "trackingToken": {
+                                  "description": "Opaque token for this result",
+                                  "type": "string",
+                                },
+                                "url": {
+                                  "description": "URL of the search result",
+                                  "type": "string",
+                                },
+                              },
+                              "type": "object",
+                            },
+                            "type": "array",
+                          },
+                        },
+                        "required": [
+                          "relation",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "name",
+                    "obfuscatedId",
+                  ],
+                  "type": "object",
+                },
+                "type": "array",
+              },
+              "query": {
+                "description": "The search terms",
+                "type": "string",
+              },
+              "requestOptions": {
+                "additionalProperties": false,
+                "description": "Options for the search request",
+                "properties": {
+                  "authTokens": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "accessToken": {
+                          "description": "The access token",
+                          "type": "string",
+                        },
+                        "authUser": {
+                          "description": "User associated with this token",
+                          "type": "string",
+                        },
+                        "datasource": {
+                          "description": "The datasource this token is for",
+                          "type": "string",
+                        },
+                        "expiration": {
+                          "description": "Token expiration timestamp",
+                          "type": "number",
+                        },
+                        "scope": {
+                          "description": "OAuth scope of the token",
+                          "type": "string",
+                        },
+                        "tokenType": {
+                          "description": "Type of the token",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "accessToken",
+                        "datasource",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                  "datasourceFilter": {
+                    "description": "Filter results to a single datasource name",
+                    "type": "string",
+                  },
+                  "datasourcesFilter": {
+                    "description": "Filter results to one or more datasources",
+                    "items": {
+                      "type": "string",
+                    },
+                    "type": "array",
+                  },
+                  "defaultFacets": {
+                    "description": "Facets for which FacetResults should be fetched",
+                    "items": {
+                      "type": "string",
+                    },
+                    "type": "array",
+                  },
+                  "disableQueryAutocorrect": {
+                    "description": "Disables automatic adjustment of the input query",
+                    "type": "boolean",
+                  },
+                  "disableSpellcheck": {
+                    "description": "Whether to disable spellcheck",
+                    "type": "boolean",
+                  },
+                  "exclusions": {
+                    "additionalProperties": false,
+                    "description": "Filters specifying content to avoid in search results",
+                    "properties": {
+                      "containerSpecs": {
+                        "items": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "url": {
+                                  "description": "The URL of the document",
+                                  "type": "string",
+                                },
+                              },
+                              "type": "object",
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "id": {
+                                  "description": "The ID of the document",
+                                  "type": "string",
+                                },
+                              },
+                              "type": "object",
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "contentId": {
+                                  "description": "The id for user generated content",
+                                  "type": "number",
+                                },
+                                "docType": {
+                                  "description": "The specific type of the user generated content type",
+                                  "type": "string",
+                                },
+                                "ugcType": {
+                                  "description": "The type of the user generated content",
+                                  "enum": [
+                                    "ANNOUNCEMENTS",
+                                    "ANSWERS",
+                                    "COLLECTIONS",
+                                    "SHORTCUTS",
+                                  ],
+                                  "type": "string",
+                                },
+                              },
+                              "type": "object",
+                            },
+                          ],
+                        },
+                        "type": "array",
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "facetBucketFilter": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "facet": {
+                        "description": "The facet to filter",
+                        "type": "string",
+                      },
+                      "prefix": {
+                        "description": "Prefix to filter facet values by",
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "facetBucketSize": {
+                    "type": "number",
+                  },
+                  "facetFilterSets": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "filters": {
+                          "description": "List of filters in this set",
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "fieldName": {
+                                "description": "Name of the field to filter on",
+                                "type": "string",
+                              },
+                              "groupName": {
+                                "description": "Name of the filter group",
+                                "type": "string",
+                              },
+                              "values": {
+                                "description": "Values to filter by",
+                                "items": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "isNegated": {
+                                      "description": "DEPRECATED - Whether the filter is negated",
+                                      "type": "boolean",
+                                    },
+                                    "relationType": {
+                                      "description": "Type of relation",
+                                      "enum": [
+                                        "EQUALS",
+                                        "ID_EQUALS",
+                                        "LT",
+                                        "GT",
+                                      ],
+                                      "type": "string",
+                                    },
+                                    "value": {
+                                      "description": "Filter value",
+                                      "type": "string",
+                                    },
+                                  },
+                                  "required": [
+                                    "value",
+                                  ],
+                                  "type": "object",
+                                },
+                                "type": "array",
+                              },
+                            },
+                            "required": [
+                              "fieldName",
+                              "values",
+                            ],
+                            "type": "object",
+                          },
+                          "type": "array",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                  "facetFilters": {
+                    "description": "List of filters for the query (ANDed together)",
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "fieldName": {
+                          "description": "Name of the field to filter on",
+                          "type": "string",
+                        },
+                        "groupName": {
+                          "description": "Name of the filter group",
+                          "type": "string",
+                        },
+                        "values": {
+                          "description": "Values to filter by",
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "isNegated": {
+                                "description": "DEPRECATED - Whether the filter is negated",
+                                "type": "boolean",
+                              },
+                              "relationType": {
+                                "description": "Type of relation",
+                                "enum": [
+                                  "EQUALS",
+                                  "ID_EQUALS",
+                                  "LT",
+                                  "GT",
+                                ],
+                                "type": "string",
+                              },
+                              "value": {
+                                "description": "Filter value",
+                                "type": "string",
+                              },
+                            },
+                            "required": [
+                              "value",
+                            ],
+                            "type": "object",
+                          },
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "fieldName",
+                        "values",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                  "fetchAllDatasourceCounts": {
+                    "description": "Return result counts for all supported datasources",
+                    "type": "boolean",
+                  },
+                  "inclusions": {
+                    "additionalProperties": false,
+                    "description": "Filters to restrict search results to only specified content",
+                    "properties": {
+                      "containerSpecs": {
+                        "items": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "url": {
+                                  "description": "The URL of the document",
+                                  "type": "string",
+                                },
+                              },
+                              "type": "object",
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "id": {
+                                  "description": "The ID of the document",
+                                  "type": "string",
+                                },
+                              },
+                              "type": "object",
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "contentId": {
+                                  "description": "The id for user generated content",
+                                  "type": "number",
+                                },
+                                "docType": {
+                                  "description": "The specific type of the user generated content type",
+                                  "type": "string",
+                                },
+                                "ugcType": {
+                                  "description": "The type of the user generated content",
+                                  "enum": [
+                                    "ANNOUNCEMENTS",
+                                    "ANSWERS",
+                                    "COLLECTIONS",
+                                    "SHORTCUTS",
+                                  ],
+                                  "type": "string",
+                                },
+                              },
+                              "type": "object",
+                            },
+                          ],
+                        },
+                        "type": "array",
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "queryOverridesFacetFilters": {
+                    "description": "If true, query operators override facet filters in case of conflict",
+                    "type": "boolean",
+                  },
+                  "responseHints": {
+                    "description": "Hints for the response content",
+                    "items": {
+                      "enum": [
+                        "ALL_RESULT_COUNTS",
+                        "FACET_RESULTS",
+                        "QUERY_METADATA",
+                        "RESULTS",
+                        "SPELLCHECK_METADATA",
+                      ],
+                      "type": "string",
+                    },
+                    "type": "array",
+                  },
+                  "returnLlmContentOverSnippets": {
+                    "description": "Enables expanded content to be returned for LLM usage",
+                    "type": "boolean",
+                  },
+                  "timezoneOffset": {
+                    "description": "Offset of client timezone in minutes from UTC",
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "facetBucketSize",
+                ],
+                "type": "object",
+              },
+              "resultTabIds": {
+                "description": "Unique IDs of result tabs to fetch",
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+              "timeoutMillis": {
+                "description": "Request timeout in milliseconds",
+                "type": "number",
+              },
+              "timestamp": {
+                "description": "ISO 8601 timestamp of client request",
+                "type": "string",
+              },
+              "trackingToken": {
+                "description": "Previous tracking token for same query",
+                "type": "string",
+              },
+            },
+            "required": [
+              "query",
+            ],
+            "type": "object",
+          },
+        },
+      }
+    `);
+  });
+
+  it('should convert ChatSchema to JSON Schema format', () => {
+    const jsonSchema = zodToJsonSchema(ChatSchema, {
+      name: 'ChatSchema',
+      $refStrategy: 'none',
+    });
+
+    expect(jsonSchema).toMatchInlineSnapshot(`
+      {
+        "$ref": "#/definitions/ChatSchema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "definitions": {
+          "ChatSchema": {
+            "additionalProperties": false,
+            "properties": {
+              "agentConfig": {
+                "additionalProperties": false,
+                "description": "Describes the agent that will execute the request",
+                "properties": {
+                  "agent": {
+                    "default": "DEFAULT",
+                    "description": "Name of the agent",
+                    "enum": [
+                      "DEFAULT",
+                      "GPT",
+                    ],
+                    "type": "string",
+                  },
+                  "mode": {
+                    "default": "DEFAULT",
+                    "description": "Top level modes to run GleanChat in",
+                    "enum": [
+                      "DEFAULT",
+                      "QUICK",
+                    ],
+                    "type": "string",
+                  },
+                },
+                "type": "object",
+              },
+              "applicationId": {
+                "description": "ID of the application this request originates from",
+                "type": "string",
+              },
+              "chatId": {
+                "description": "ID of the Chat to retrieve context from and add messages to",
+                "type": "string",
+              },
+              "exclusions": {
+                "additionalProperties": false,
+                "description": "Filters that disallow chat from accessing certain content",
+                "properties": {
+                  "containerSpecs": {
+                    "description": "Specifications for containers that should be used as part of the restriction",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "url": {
+                              "description": "The URL of the document",
+                              "type": "string",
+                            },
+                          },
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "id": {
+                              "description": "The ID of the document",
+                              "type": "string",
+                            },
+                          },
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "contentId": {
+                              "description": "The id for user generated content",
+                              "type": "number",
+                            },
+                            "docType": {
+                              "description": "The specific type of the user generated content type",
+                              "type": "string",
+                            },
+                            "ugcType": {
+                              "description": "The type of the user generated content",
+                              "enum": [
+                                "ANNOUNCEMENTS",
+                                "ANSWERS",
+                                "COLLECTIONS",
+                                "SHORTCUTS",
+                              ],
+                              "type": "string",
+                            },
+                          },
+                          "type": "object",
+                        },
+                      ],
+                    },
+                    "type": "array",
+                  },
+                },
+                "type": "object",
+              },
+              "inclusions": {
+                "additionalProperties": false,
+                "description": "Filters that only allow chat to access certain content",
+                "properties": {
+                  "containerSpecs": {
+                    "description": "Specifications for containers that should be used as part of the restriction",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "url": {
+                              "description": "The URL of the document",
+                              "type": "string",
+                            },
+                          },
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "id": {
+                              "description": "The ID of the document",
+                              "type": "string",
+                            },
+                          },
+                          "type": "object",
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "contentId": {
+                              "description": "The id for user generated content",
+                              "type": "number",
+                            },
+                            "docType": {
+                              "description": "The specific type of the user generated content type",
+                              "type": "string",
+                            },
+                            "ugcType": {
+                              "description": "The type of the user generated content",
+                              "enum": [
+                                "ANNOUNCEMENTS",
+                                "ANSWERS",
+                                "COLLECTIONS",
+                                "SHORTCUTS",
+                              ],
+                              "type": "string",
+                            },
+                          },
+                          "type": "object",
+                        },
+                      ],
+                    },
+                    "type": "array",
+                  },
+                },
+                "type": "object",
+              },
+              "messages": {
+                "description": "List of chat messages, from most recent to least recent",
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "agentConfig": {
+                      "additionalProperties": false,
+                      "description": "Agent config that generated this message",
+                      "properties": {
+                        "agent": {
+                          "default": "DEFAULT",
+                          "description": "Name of the agent",
+                          "enum": [
+                            "DEFAULT",
+                            "GPT",
+                          ],
+                          "type": "string",
+                        },
+                        "mode": {
+                          "default": "DEFAULT",
+                          "description": "Top level modes to run GleanChat in",
+                          "enum": [
+                            "DEFAULT",
+                            "QUICK",
+                          ],
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "author": {
+                      "default": "USER",
+                      "description": "Author of the message",
+                      "enum": [
+                        "USER",
+                        "GLEAN_AI",
+                      ],
+                      "type": "string",
+                    },
+                    "citations": {
+                      "description": "Citations used to generate the response",
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "sourceDocument": {
+                            "additionalProperties": false,
+                            "description": "The document that is the source of the citation",
+                            "properties": {
+                              "id": {
+                                "description": "Document ID",
+                                "type": "string",
+                              },
+                              "referenceRanges": {
+                                "description": "Ranges within the document that are referenced",
+                                "items": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "textRange": {
+                                      "additionalProperties": false,
+                                      "description": "A subsection of text with special formatting",
+                                      "properties": {
+                                        "document": {
+                                          "additionalProperties": false,
+                                          "description": "Referenced document",
+                                          "properties": {
+                                            "connectorType": {
+                                              "description": "The type of connector used to extract the document",
+                                              "enum": [
+                                                "API_CRAWL",
+                                                "BROWSER_CRAWL",
+                                                "BROWSER_HISTORY",
+                                                "BUILTIN",
+                                                "FEDERATED_SEARCH",
+                                                "PUSH_API",
+                                                "WEB_CRAWL",
+                                                "NATIVE_HISTORY",
+                                              ],
+                                              "type": "string",
+                                            },
+                                            "containerDocument": {
+                                              "description": "The container document",
+                                            },
+                                            "content": {
+                                              "additionalProperties": false,
+                                              "properties": {
+                                                "fullTextList": {
+                                                  "description": "The plaintext content of the document",
+                                                  "items": {
+                                                    "type": "string",
+                                                  },
+                                                  "type": "array",
+                                                },
+                                              },
+                                              "type": "object",
+                                            },
+                                            "datasource": {
+                                              "description": "The app or other repository type from which the document was extracted",
+                                              "type": "string",
+                                            },
+                                            "docType": {
+                                              "description": "The datasource-specific type of the document",
+                                              "type": "string",
+                                            },
+                                            "id": {
+                                              "description": "The Glean Document ID",
+                                              "type": "string",
+                                            },
+                                            "metadata": {
+                                              "additionalProperties": false,
+                                              "properties": {
+                                                "customData": {
+                                                  "additionalProperties": {},
+                                                  "description": "Custom metadata fields",
+                                                  "type": "object",
+                                                },
+                                              },
+                                              "type": "object",
+                                            },
+                                            "parentDocument": {
+                                              "description": "The parent document",
+                                            },
+                                            "sections": {
+                                              "description": "A list of content sub-sections in the document",
+                                              "items": {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                  "content": {
+                                                    "description": "Section content",
+                                                    "type": "string",
+                                                  },
+                                                  "endIndex": {
+                                                    "description": "End index of section in document",
+                                                    "type": "number",
+                                                  },
+                                                  "level": {
+                                                    "description": "Heading level of the section",
+                                                    "type": "number",
+                                                  },
+                                                  "startIndex": {
+                                                    "description": "Start index of section in document",
+                                                    "type": "number",
+                                                  },
+                                                  "title": {
+                                                    "description": "Section title",
+                                                    "type": "string",
+                                                  },
+                                                  "type": {
+                                                    "description": "Type of section",
+                                                    "type": "string",
+                                                  },
+                                                },
+                                                "type": "object",
+                                              },
+                                              "type": "array",
+                                            },
+                                            "title": {
+                                              "description": "The title of the document",
+                                              "type": "string",
+                                            },
+                                            "url": {
+                                              "description": "A permalink for the document",
+                                              "type": "string",
+                                            },
+                                          },
+                                          "required": [
+                                            "id",
+                                          ],
+                                          "type": "object",
+                                        },
+                                        "endIndex": {
+                                          "description": "Exclusive end index of the range",
+                                          "type": "number",
+                                        },
+                                        "startIndex": {
+                                          "description": "Inclusive start index of the range",
+                                          "type": "number",
+                                        },
+                                        "type": {
+                                          "description": "Type of formatting to apply",
+                                          "enum": [
+                                            "BOLD",
+                                            "CITATION",
+                                            "LINK",
+                                          ],
+                                          "type": "string",
+                                        },
+                                        "url": {
+                                          "description": "URL associated with the range",
+                                          "type": "string",
+                                        },
+                                      },
+                                      "required": [
+                                        "startIndex",
+                                        "endIndex",
+                                        "type",
+                                      ],
+                                      "type": "object",
+                                    },
+                                  },
+                                  "required": [
+                                    "textRange",
+                                  ],
+                                  "type": "object",
+                                },
+                                "type": "array",
+                              },
+                              "title": {
+                                "description": "Document title",
+                                "type": "string",
+                              },
+                            },
+                            "required": [
+                              "id",
+                            ],
+                            "type": "object",
+                          },
+                        },
+                        "required": [
+                          "sourceDocument",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "fragments": {
+                      "description": "Rich data representing the response or request",
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "action": {
+                            "additionalProperties": false,
+                            "description": "Action information for the fragment",
+                            "properties": {
+                              "parameters": {
+                                "additionalProperties": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "description": {
+                                      "description": "Description of the parameter",
+                                      "type": "string",
+                                    },
+                                    "displayName": {
+                                      "description": "Display name for the parameter",
+                                      "type": "string",
+                                    },
+                                    "isRequired": {
+                                      "description": "Whether the parameter is required",
+                                      "type": "boolean",
+                                    },
+                                    "label": {
+                                      "description": "Label for the parameter",
+                                      "type": "string",
+                                    },
+                                    "type": {
+                                      "description": "Data type of the parameter",
+                                      "enum": [
+                                        "UNKNOWN",
+                                        "INTEGER",
+                                        "STRING",
+                                        "BOOLEAN",
+                                      ],
+                                      "type": "string",
+                                    },
+                                    "value": {
+                                      "description": "Value of the parameter",
+                                      "type": "string",
+                                    },
+                                  },
+                                  "type": "object",
+                                },
+                                "description": "Map of parameter names to parameter definitions",
+                                "type": "object",
+                              },
+                            },
+                            "type": "object",
+                          },
+                          "file": {
+                            "additionalProperties": false,
+                            "description": "File referenced in the message fragment",
+                            "properties": {
+                              "id": {
+                                "description": "Unique identifier for the file",
+                                "type": "string",
+                              },
+                              "name": {
+                                "description": "Name of the file",
+                                "type": "string",
+                              },
+                            },
+                            "required": [
+                              "id",
+                              "name",
+                            ],
+                            "type": "object",
+                          },
+                          "querySuggestion": {
+                            "additionalProperties": false,
+                            "description": "Search query suggestion associated with the fragment",
+                            "properties": {
+                              "datasource": {
+                                "description": "The datasource associated with the suggestion",
+                                "type": "string",
+                              },
+                              "label": {
+                                "description": "User-facing description of the suggestion",
+                                "type": "string",
+                              },
+                              "query": {
+                                "description": "The suggested query",
+                                "type": "string",
+                              },
+                            },
+                            "required": [
+                              "query",
+                            ],
+                            "type": "object",
+                          },
+                          "structuredResults": {
+                            "description": "Structured results associated with the fragment",
+                            "items": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "document": {
+                                  "additionalProperties": false,
+                                  "description": "The document this result represents",
+                                  "properties": {
+                                    "connectorType": {
+                                      "description": "The type of connector used to extract the document",
+                                      "enum": [
+                                        "API_CRAWL",
+                                        "BROWSER_CRAWL",
+                                        "BROWSER_HISTORY",
+                                        "BUILTIN",
+                                        "FEDERATED_SEARCH",
+                                        "PUSH_API",
+                                        "WEB_CRAWL",
+                                        "NATIVE_HISTORY",
+                                      ],
+                                      "type": "string",
+                                    },
+                                    "containerDocument": {
+                                      "description": "The container document",
+                                    },
+                                    "content": {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "fullTextList": {
+                                          "description": "The plaintext content of the document",
+                                          "items": {
+                                            "type": "string",
+                                          },
+                                          "type": "array",
+                                        },
+                                      },
+                                      "type": "object",
+                                    },
+                                    "datasource": {
+                                      "description": "The app or other repository type from which the document was extracted",
+                                      "type": "string",
+                                    },
+                                    "docType": {
+                                      "description": "The datasource-specific type of the document",
+                                      "type": "string",
+                                    },
+                                    "id": {
+                                      "description": "The Glean Document ID",
+                                      "type": "string",
+                                    },
+                                    "metadata": {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "customData": {
+                                          "additionalProperties": {},
+                                          "description": "Custom metadata fields",
+                                          "type": "object",
+                                        },
+                                      },
+                                      "type": "object",
+                                    },
+                                    "parentDocument": {
+                                      "description": "The parent document",
+                                    },
+                                    "sections": {
+                                      "description": "A list of content sub-sections in the document",
+                                      "items": {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "content": {
+                                            "description": "Section content",
+                                            "type": "string",
+                                          },
+                                          "endIndex": {
+                                            "description": "End index of section in document",
+                                            "type": "number",
+                                          },
+                                          "level": {
+                                            "description": "Heading level of the section",
+                                            "type": "number",
+                                          },
+                                          "startIndex": {
+                                            "description": "Start index of section in document",
+                                            "type": "number",
+                                          },
+                                          "title": {
+                                            "description": "Section title",
+                                            "type": "string",
+                                          },
+                                          "type": {
+                                            "description": "Type of section",
+                                            "type": "string",
+                                          },
+                                        },
+                                        "type": "object",
+                                      },
+                                      "type": "array",
+                                    },
+                                    "title": {
+                                      "description": "The title of the document",
+                                      "type": "string",
+                                    },
+                                    "url": {
+                                      "description": "A permalink for the document",
+                                      "type": "string",
+                                    },
+                                  },
+                                  "required": [
+                                    "id",
+                                  ],
+                                  "type": "object",
+                                },
+                                "snippets": {
+                                  "description": "Any snippets associated to the populated object",
+                                  "items": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "mimeType": {
+                                        "description": "The mime type of the snippets",
+                                        "type": "string",
+                                      },
+                                      "ranges": {
+                                        "description": "The bolded ranges within text",
+                                        "items": {
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "document": {
+                                              "additionalProperties": false,
+                                              "description": "Referenced document",
+                                              "properties": {
+                                                "connectorType": {
+                                                  "description": "The type of connector used to extract the document",
+                                                  "enum": [
+                                                    "API_CRAWL",
+                                                    "BROWSER_CRAWL",
+                                                    "BROWSER_HISTORY",
+                                                    "BUILTIN",
+                                                    "FEDERATED_SEARCH",
+                                                    "PUSH_API",
+                                                    "WEB_CRAWL",
+                                                    "NATIVE_HISTORY",
+                                                  ],
+                                                  "type": "string",
+                                                },
+                                                "containerDocument": {
+                                                  "description": "The container document",
+                                                },
+                                                "content": {
+                                                  "additionalProperties": false,
+                                                  "properties": {
+                                                    "fullTextList": {
+                                                      "description": "The plaintext content of the document",
+                                                      "items": {
+                                                        "type": "string",
+                                                      },
+                                                      "type": "array",
+                                                    },
+                                                  },
+                                                  "type": "object",
+                                                },
+                                                "datasource": {
+                                                  "description": "The app or other repository type from which the document was extracted",
+                                                  "type": "string",
+                                                },
+                                                "docType": {
+                                                  "description": "The datasource-specific type of the document",
+                                                  "type": "string",
+                                                },
+                                                "id": {
+                                                  "description": "The Glean Document ID",
+                                                  "type": "string",
+                                                },
+                                                "metadata": {
+                                                  "additionalProperties": false,
+                                                  "properties": {
+                                                    "customData": {
+                                                      "additionalProperties": {},
+                                                      "description": "Custom metadata fields",
+                                                      "type": "object",
+                                                    },
+                                                  },
+                                                  "type": "object",
+                                                },
+                                                "parentDocument": {
+                                                  "description": "The parent document",
+                                                },
+                                                "sections": {
+                                                  "description": "A list of content sub-sections in the document",
+                                                  "items": {
+                                                    "additionalProperties": false,
+                                                    "properties": {
+                                                      "content": {
+                                                        "description": "Section content",
+                                                        "type": "string",
+                                                      },
+                                                      "endIndex": {
+                                                        "description": "End index of section in document",
+                                                        "type": "number",
+                                                      },
+                                                      "level": {
+                                                        "description": "Heading level of the section",
+                                                        "type": "number",
+                                                      },
+                                                      "startIndex": {
+                                                        "description": "Start index of section in document",
+                                                        "type": "number",
+                                                      },
+                                                      "title": {
+                                                        "description": "Section title",
+                                                        "type": "string",
+                                                      },
+                                                      "type": {
+                                                        "description": "Type of section",
+                                                        "type": "string",
+                                                      },
+                                                    },
+                                                    "type": "object",
+                                                  },
+                                                  "type": "array",
+                                                },
+                                                "title": {
+                                                  "description": "The title of the document",
+                                                  "type": "string",
+                                                },
+                                                "url": {
+                                                  "description": "A permalink for the document",
+                                                  "type": "string",
+                                                },
+                                              },
+                                              "required": [
+                                                "id",
+                                              ],
+                                              "type": "object",
+                                            },
+                                            "endIndex": {
+                                              "description": "Exclusive end index of the range",
+                                              "type": "number",
+                                            },
+                                            "startIndex": {
+                                              "description": "Inclusive start index of the range",
+                                              "type": "number",
+                                            },
+                                            "type": {
+                                              "description": "Type of formatting to apply",
+                                              "enum": [
+                                                "BOLD",
+                                                "CITATION",
+                                                "LINK",
+                                              ],
+                                              "type": "string",
+                                            },
+                                            "url": {
+                                              "description": "URL associated with the range",
+                                              "type": "string",
+                                            },
+                                          },
+                                          "required": [
+                                            "startIndex",
+                                            "endIndex",
+                                            "type",
+                                          ],
+                                          "type": "object",
+                                        },
+                                        "type": "array",
+                                      },
+                                      "snippet": {
+                                        "description": "A matching snippet from the document with query term matches",
+                                        "type": "string",
+                                      },
+                                      "snippetTextOrdering": {
+                                        "description": "Used for sorting based off snippet location",
+                                        "type": "number",
+                                      },
+                                      "text": {
+                                        "description": "A matching snippet from the document with no highlights",
+                                        "type": "string",
+                                      },
+                                      "url": {
+                                        "description": "URL that links to the position of the snippet text",
+                                        "type": "string",
+                                      },
+                                    },
+                                    "required": [
+                                      "snippet",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  "type": "array",
+                                },
+                                "trackingToken": {
+                                  "description": "An opaque token that represents this particular result",
+                                  "type": "string",
+                                },
+                              },
+                              "type": "object",
+                            },
+                            "type": "array",
+                          },
+                          "text": {
+                            "description": "Text content of the fragment",
+                            "type": "string",
+                          },
+                        },
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "hasMoreFragments": {
+                      "description": "Whether more fragments will follow in subsequent messages",
+                      "type": "boolean",
+                    },
+                    "messageId": {
+                      "description": "Unique server-side generated ID for the message",
+                      "type": "string",
+                    },
+                    "messageType": {
+                      "default": "CONTENT",
+                      "description": "Type of the message",
+                      "enum": [
+                        "UPDATE",
+                        "CONTENT",
+                        "CONTEXT",
+                        "DEBUG",
+                        "DEBUG_EXTERNAL",
+                        "ERROR",
+                        "HEADING",
+                        "WARNING",
+                      ],
+                      "type": "string",
+                    },
+                    "ts": {
+                      "description": "Response timestamp of the message",
+                      "type": "string",
+                    },
+                    "uploadedFileIds": {
+                      "description": "IDs of files uploaded in the message",
+                      "items": {
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "type": "object",
+                },
+                "type": "array",
+              },
+              "saveChat": {
+                "description": "Save the interaction as a Chat for the user to access later",
+                "type": "boolean",
+              },
+              "stream": {
+                "description": "If true, response lines will be streamed one-by-one as they become available",
+                "type": "boolean",
+              },
+              "timeoutMillis": {
+                "description": "Request timeout in milliseconds",
+                "type": "number",
+              },
+              "timezoneOffset": {
+                "description": "Offset of client timezone in minutes from UTC",
+                "type": "number",
+              },
+            },
+            "required": [
+              "messages",
+            ],
+            "type": "object",
+          },
+        },
+      }
+    `);
+  });
+});

--- a/src/tools/chat.ts
+++ b/src/tools/chat.ts
@@ -14,7 +14,7 @@ import {
  *
  * @type {z.ZodObject}
  */
-export const AgentConfigSchema = z.object({
+const AgentConfigSchema = z.object({
   agent: z
     .enum(['DEFAULT', 'GPT'])
     .optional()
@@ -33,7 +33,7 @@ export const AgentConfigSchema = z.object({
  *
  * @type {z.ZodObject}
  */
-export const ParameterSchema = z.object({
+const ParameterSchema = z.object({
   description: z.string().optional().describe('Description of the parameter'),
   displayName: z.string().optional().describe('Display name for the parameter'),
   isRequired: z
@@ -54,7 +54,7 @@ export const ParameterSchema = z.object({
  *
  * @type {z.ZodObject}
  */
-export const ActionSchema = z.object({
+const ActionSchema = z.object({
   parameters: z
     .record(z.string(), ParameterSchema)
     .optional()
@@ -67,7 +67,7 @@ export const ActionSchema = z.object({
  *
  * @type {z.ZodObject}
  */
-export const ChatFileSchema = z.object({
+const ChatFileSchema = z.object({
   id: z.string().describe('Unique identifier for the file'),
   name: z.string().describe('Name of the file'),
 });
@@ -78,7 +78,7 @@ export const ChatFileSchema = z.object({
  *
  * @type {z.ZodObject}
  */
-export const ChatMessageCitationSchema = z.object({
+const ChatMessageCitationSchema = z.object({
   sourceDocument: z
     .object({
       id: z.string().describe('Document ID'),
@@ -100,7 +100,7 @@ export const ChatMessageCitationSchema = z.object({
 /**
  * Schema for structured results in chat message fragments.
  */
-export const StructuredResultSchema = z.object({
+const StructuredResultSchema = z.object({
   document: DocumentSchema.optional().describe(
     'The document this result represents',
   ),
@@ -120,7 +120,7 @@ export const StructuredResultSchema = z.object({
  *
  * @type {z.ZodObject}
  */
-export const ChatMessageFragmentSchema = z.object({
+const ChatMessageFragmentSchema = z.object({
   text: z.string().optional().describe('Text content of the fragment'),
   action: ActionSchema.optional().describe(
     'Action information for the fragment',
@@ -143,7 +143,7 @@ export const ChatMessageFragmentSchema = z.object({
  *
  * @type {z.ZodObject}
  */
-export const ChatRestrictionFiltersSchema = z.object({
+const ChatRestrictionFiltersSchema = z.object({
   containerSpecs: z
     .array(DocumentSpecSchema)
     .optional()
@@ -158,7 +158,7 @@ export const ChatRestrictionFiltersSchema = z.object({
  *
  * @type {z.ZodObject}
  */
-export const ChatMessageSchema = z.object({
+const ChatMessageSchema = z.object({
   agentConfig: AgentConfigSchema.optional().describe(
     'Agent config that generated this message',
   ),

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -1,0 +1,193 @@
+/**
+ * @fileoverview Shared schema definitions for Glean MCP server tools.
+ *
+ * This module contains schema definitions that are used across multiple tools,
+ * particularly between search and chat functionality.
+ */
+
+import { z } from 'zod';
+
+/**
+ * Schema for document content in search requests.
+ */
+export const DocumentContentSchema = z.object({
+  fullTextList: z
+    .array(z.string())
+    .optional()
+    .describe('The plaintext content of the document'),
+});
+
+/**
+ * Schema for document metadata in search requests.
+ */
+export const DocumentMetadataSchema = z.object({
+  customData: z.record(z.any()).optional().describe('Custom metadata fields'),
+});
+
+/**
+ * Schema for document section in search requests.
+ */
+export const DocumentSectionSchema = z.object({
+  title: z.string().optional().describe('Section title'),
+  content: z.string().optional().describe('Section content'),
+  startIndex: z
+    .number()
+    .optional()
+    .describe('Start index of section in document'),
+  endIndex: z.number().optional().describe('End index of section in document'),
+  level: z.number().optional().describe('Heading level of the section'),
+  type: z.string().optional().describe('Type of section'),
+});
+
+/**
+ * Schema for document in search requests.
+ */
+export type DocumentSchemaType = z.ZodObject<{
+  id: z.ZodString;
+  datasource: z.ZodOptional<z.ZodString>;
+  connectorType: z.ZodOptional<
+    z.ZodEnum<
+      [
+        'API_CRAWL',
+        'BROWSER_CRAWL',
+        'BROWSER_HISTORY',
+        'BUILTIN',
+        'FEDERATED_SEARCH',
+        'PUSH_API',
+        'WEB_CRAWL',
+        'NATIVE_HISTORY',
+      ]
+    >
+  >;
+  docType: z.ZodOptional<z.ZodString>;
+  content: z.ZodOptional<typeof DocumentContentSchema>;
+  containerDocument: z.ZodOptional<z.ZodLazy<any>>;
+  parentDocument: z.ZodOptional<z.ZodLazy<any>>;
+  title: z.ZodOptional<z.ZodString>;
+  url: z.ZodOptional<z.ZodString>;
+  metadata: z.ZodOptional<typeof DocumentMetadataSchema>;
+  sections: z.ZodOptional<z.ZodArray<typeof DocumentSectionSchema>>;
+}>;
+
+export const DocumentSchema: DocumentSchemaType = z.object({
+  id: z.string().describe('The Glean Document ID'),
+  datasource: z
+    .string()
+    .optional()
+    .describe(
+      'The app or other repository type from which the document was extracted',
+    ),
+  connectorType: z
+    .enum([
+      'API_CRAWL',
+      'BROWSER_CRAWL',
+      'BROWSER_HISTORY',
+      'BUILTIN',
+      'FEDERATED_SEARCH',
+      'PUSH_API',
+      'WEB_CRAWL',
+      'NATIVE_HISTORY',
+    ])
+    .optional()
+    .describe('The type of connector used to extract the document'),
+  docType: z
+    .string()
+    .optional()
+    .describe('The datasource-specific type of the document'),
+  content: DocumentContentSchema.optional(),
+  containerDocument: z
+    .lazy(() => DocumentSchema)
+    .optional()
+    .describe('The container document'),
+  parentDocument: z
+    .lazy(() => DocumentSchema)
+    .optional()
+    .describe('The parent document'),
+  title: z.string().optional().describe('The title of the document'),
+  url: z.string().optional().describe('A permalink for the document'),
+  metadata: DocumentMetadataSchema.optional(),
+  sections: z
+    .array(DocumentSectionSchema)
+    .optional()
+    .describe('A list of content sub-sections in the document'),
+});
+
+/**
+ * Schema for text range in search requests.
+ */
+export const TextRangeSchema = z.object({
+  startIndex: z.number().describe('Inclusive start index of the range'),
+  endIndex: z.number().describe('Exclusive end index of the range'),
+  type: z
+    .enum(['BOLD', 'CITATION', 'LINK'])
+    .describe('Type of formatting to apply'),
+  url: z.string().optional().describe('URL associated with the range'),
+  document: DocumentSchema.optional().describe('Referenced document'),
+});
+
+/**
+ * Schema for search result snippet in search requests.
+ */
+export const SearchResultSnippetSchema = z.object({
+  snippet: z
+    .string()
+    .describe('A matching snippet from the document with query term matches'),
+  mimeType: z.string().optional().describe('The mime type of the snippets'),
+  text: z
+    .string()
+    .optional()
+    .describe('A matching snippet from the document with no highlights'),
+  snippetTextOrdering: z
+    .number()
+    .optional()
+    .describe('Used for sorting based off snippet location'),
+  ranges: z
+    .array(TextRangeSchema)
+    .optional()
+    .describe('The bolded ranges within text'),
+  url: z
+    .string()
+    .optional()
+    .describe('URL that links to the position of the snippet text'),
+});
+
+/**
+ * Schema for query suggestion in search requests.
+ */
+export const QuerySuggestionSchema = z.object({
+  query: z.string().describe('The suggested query'),
+  label: z
+    .string()
+    .optional()
+    .describe('User-facing description of the suggestion'),
+  datasource: z
+    .string()
+    .optional()
+    .describe('The datasource associated with the suggestion'),
+});
+
+/**
+ * Schema for document spec in search requests.
+ */
+export const DocumentSpecSchema = z.union([
+  z.object({
+    url: z.string().optional().describe('The URL of the document'),
+  }),
+  z.object({
+    id: z.string().optional().describe('The ID of the document'),
+  }),
+  z.object({
+    ugcType: z
+      .enum(['ANNOUNCEMENTS', 'ANSWERS', 'COLLECTIONS', 'SHORTCUTS'])
+      .optional()
+      .describe('The type of the user generated content'),
+    contentId: z
+      .number()
+      .optional()
+      .describe('The id for user generated content'),
+    docType: z
+      .string()
+      .optional()
+      .describe('The specific type of the user generated content type'),
+  }),
+]);

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -40,6 +40,25 @@ export const DocumentSectionSchema = z.object({
 });
 
 /**
+ * Schema for simplified document references to avoid circular dependencies.
+ */
+export const DocumentReferenceSchema = z.object({
+  id: z.string().describe('The Glean Document ID'),
+  title: z.string().optional().describe('The title of the document'),
+  url: z.string().optional().describe('A permalink for the document'),
+  datasource: z
+    .string()
+    .optional()
+    .describe(
+      'The app or other repository type from which the document was extracted',
+    ),
+  docType: z
+    .string()
+    .optional()
+    .describe('The datasource-specific type of the document'),
+});
+
+/**
  * Schema for document in search requests.
  */
 export type DocumentSchemaType = z.ZodObject<{
@@ -61,8 +80,8 @@ export type DocumentSchemaType = z.ZodObject<{
   >;
   docType: z.ZodOptional<z.ZodString>;
   content: z.ZodOptional<typeof DocumentContentSchema>;
-  containerDocument: z.ZodOptional<z.ZodLazy<any>>;
-  parentDocument: z.ZodOptional<z.ZodLazy<any>>;
+  containerDocument: z.ZodOptional<typeof DocumentReferenceSchema>;
+  parentDocument: z.ZodOptional<typeof DocumentReferenceSchema>;
   title: z.ZodOptional<z.ZodString>;
   url: z.ZodOptional<z.ZodString>;
   metadata: z.ZodOptional<typeof DocumentMetadataSchema>;
@@ -95,14 +114,12 @@ export const DocumentSchema: DocumentSchemaType = z.object({
     .optional()
     .describe('The datasource-specific type of the document'),
   content: DocumentContentSchema.optional(),
-  containerDocument: z
-    .lazy(() => DocumentSchema)
-    .optional()
-    .describe('The container document'),
-  parentDocument: z
-    .lazy(() => DocumentSchema)
-    .optional()
-    .describe('The parent document'),
+  containerDocument: DocumentReferenceSchema.optional().describe(
+    'The container document',
+  ),
+  parentDocument: DocumentReferenceSchema.optional().describe(
+    'The parent document',
+  ),
   title: z.string().optional().describe('The title of the document'),
   url: z.string().optional().describe('A permalink for the document'),
   metadata: DocumentMetadataSchema.optional(),

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -12,6 +12,49 @@ import { z } from 'zod';
 import { getClient } from '../common/client.js';
 
 /**
+ * Schema for related documents in search requests.
+ * Matches the Glean SDK's RelatedDocuments type structure.
+ */
+export const RelatedDocumentsSchema = z.object({
+  relation: z
+    .enum([
+      'ATTACHMENT',
+      'CANONICAL',
+      'CASE',
+      'CONTACT',
+      'CONVERSATION_MESSAGES',
+      'EXPERT',
+      'FROM',
+      'HIGHLIGHT',
+      'OPPORTUNITY',
+      'RECENT',
+      'SOURCE',
+      'TICKET',
+      'TRANSCRIPT',
+      'WITH',
+    ])
+    .describe('How this document relates to the including entity.'),
+  associatedEntityId: z
+    .string()
+    .optional()
+    .describe('Which entity in the response that this entity relates to.'),
+  querySuggestion: z
+    .any()
+    .optional()
+    .describe('Query suggestion for this relation'),
+  documents: z
+    .array(z.any())
+    .optional()
+    .describe(
+      'A truncated list of documents with this relation. TO BE DEPRECATED.',
+    ),
+  results: z
+    .array(z.any())
+    .optional()
+    .describe('A truncated list of documents associated with this relation.'),
+});
+
+/**
  * Schema for a person entity in search requests.
  * Matches the Glean SDK's Person type structure.
  *
@@ -22,7 +65,7 @@ export const PersonSchema = z.object({
   obfuscatedId: z.string(),
   email: z.string().optional(),
   metadata: z.any().optional(),
-  relatedDocuments: z.array(z.any()).optional(),
+  relatedDocuments: z.array(RelatedDocumentsSchema).optional(),
 });
 
 /**

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -12,6 +12,33 @@ import { z } from 'zod';
 import { getClient } from '../common/client.js';
 
 /**
+ * Schema for document in search requests.
+ * Basic document schema - can be expanded if needed.
+ */
+export const DocumentSchema = z.object({
+  id: z.string().describe('The Glean Document ID'),
+  title: z.string().optional().describe('The title of the document'),
+  url: z.string().optional().describe('A permalink for the document'),
+  datasource: z
+    .string()
+    .optional()
+    .describe(
+      'The app or other repository type from which the document was extracted',
+    ),
+});
+
+/**
+ * Schema for search result in search requests.
+ * Basic search result schema - can be expanded if needed.
+ */
+export const SearchResultSchema = z.object({
+  document: DocumentSchema.optional(),
+  title: z.string().optional(),
+  url: z.string().optional(),
+  snippets: z.array(z.any()).optional(),
+});
+
+/**
  * Schema for related documents in search requests.
  * Matches the Glean SDK's RelatedDocuments type structure.
  */
@@ -43,13 +70,13 @@ export const RelatedDocumentsSchema = z.object({
     .optional()
     .describe('Query suggestion for this relation'),
   documents: z
-    .array(z.any())
+    .array(DocumentSchema)
     .optional()
     .describe(
       'A truncated list of documents with this relation. TO BE DEPRECATED.',
     ),
   results: z
-    .array(z.any())
+    .array(SearchResultSchema)
     .optional()
     .describe('A truncated list of documents associated with this relation.'),
 });

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -10,39 +10,42 @@
 
 import { z } from 'zod';
 import { getClient } from '../common/client.js';
-
-/**
- * Schema for document in search requests.
- * Basic document schema - can be expanded if needed.
- */
-export const DocumentSchema = z.object({
-  id: z.string().describe('The Glean Document ID'),
-  title: z.string().optional().describe('The title of the document'),
-  url: z.string().optional().describe('A permalink for the document'),
-  datasource: z
-    .string()
-    .optional()
-    .describe(
-      'The app or other repository type from which the document was extracted',
-    ),
-});
+import {
+  DocumentSchema,
+  DocumentSpecSchema,
+  QuerySuggestionSchema,
+  SearchResultSnippetSchema,
+} from './schemas.js';
 
 /**
  * Schema for search result in search requests.
- * Basic search result schema - can be expanded if needed.
  */
-export const SearchResultSchema = z.object({
-  document: DocumentSchema.optional(),
-  title: z.string().optional(),
-  url: z.string().optional(),
-  snippets: z.array(z.any()).optional(),
+const SearchResultSchema = z.object({
+  document: DocumentSchema.optional().describe(
+    'The document this result represents',
+  ),
+  title: z.string().optional().describe('Title of the search result'),
+  url: z.string().optional().describe('URL of the search result'),
+  nativeAppUrl: z
+    .string()
+    .optional()
+    .describe('Deep link into datasource native application'),
+  snippets: z
+    .array(SearchResultSnippetSchema)
+    .optional()
+    .describe('Text content from the result document'),
+  fullText: z.string().optional().describe('The full body text of the result'),
+  fullTextList: z
+    .array(z.string())
+    .optional()
+    .describe('The full body text split by lines'),
+  trackingToken: z.string().optional().describe('Opaque token for this result'),
 });
 
 /**
  * Schema for related documents in search requests.
- * Matches the Glean SDK's RelatedDocuments type structure.
  */
-export const RelatedDocumentsSchema = z.object({
+const RelatedDocumentsSchema = z.object({
   relation: z
     .enum([
       'ATTACHMENT',
@@ -65,10 +68,7 @@ export const RelatedDocumentsSchema = z.object({
     .string()
     .optional()
     .describe('Which entity in the response that this entity relates to.'),
-  querySuggestion: z
-    .any()
-    .optional()
-    .describe('Query suggestion for this relation'),
+  querySuggestion: QuerySuggestionSchema.optional(),
   documents: z
     .array(DocumentSchema)
     .optional()
@@ -82,26 +82,30 @@ export const RelatedDocumentsSchema = z.object({
 });
 
 /**
- * Schema for a person entity in search requests.
- * Matches the Glean SDK's Person type structure.
- *
- * @type {z.ZodObject}
+ * Schema for person in search requests.
  */
-export const PersonSchema = z.object({
-  name: z.string(),
-  obfuscatedId: z.string(),
-  email: z.string().optional(),
-  metadata: z.any().optional(),
-  relatedDocuments: z.array(RelatedDocumentsSchema).optional(),
+const PersonSchema = z.object({
+  name: z.string().describe('The display name'),
+  obfuscatedId: z
+    .string()
+    .describe(
+      'An opaque identifier that can be used to request metadata for a Person',
+    ),
+  email: z.string().optional().describe('The email address of the person'),
+  metadata: z
+    .record(z.string())
+    .optional()
+    .describe('Additional metadata about the person'),
+  relatedDocuments: z
+    .array(RelatedDocumentsSchema)
+    .optional()
+    .describe('A list of documents related to this person'),
 });
 
 /**
  * Schema for facet filter value in search requests.
- * Defines the structure for facet filter values.
- *
- * @type {z.ZodObject}
  */
-export const FacetFilterValueSchema = z.object({
+const FacetFilterValueSchema = z.object({
   value: z.string().describe('Filter value'),
   relationType: z
     .enum(['EQUALS', 'ID_EQUALS', 'LT', 'GT'])
@@ -115,39 +119,61 @@ export const FacetFilterValueSchema = z.object({
 
 /**
  * Schema for facet filter in search requests.
- * Defines the structure for facet filters.
- *
- * @type {z.ZodObject}
  */
-export const FacetFilterSchema = z.object({
+const FacetFilterSchema = z.object({
   fieldName: z.string().describe('Name of the field to filter on'),
   values: z.array(FacetFilterValueSchema).describe('Values to filter by'),
+  groupName: z.string().optional().describe('Name of the filter group'),
+});
+
+/**
+ * Schema for facet filter set in search requests.
+ */
+const FacetFilterSetSchema = z.object({
+  filters: z
+    .array(FacetFilterSchema)
+    .optional()
+    .describe('List of filters in this set'),
+});
+
+/**
+ * Schema for facet bucket filter in search requests.
+ */
+const FacetBucketFilterSchema = z.object({
+  facet: z.string().optional().describe('The facet to filter'),
+  prefix: z.string().optional().describe('Prefix to filter facet values by'),
+});
+
+/**
+ * Schema for auth token in search requests.
+ */
+const AuthTokenSchema = z.object({
+  accessToken: z.string().describe('The access token'),
+  datasource: z.string().describe('The datasource this token is for'),
+  scope: z.string().optional().describe('OAuth scope of the token'),
+  tokenType: z.string().optional().describe('Type of the token'),
+  authUser: z.string().optional().describe('User associated with this token'),
+  expiration: z.number().optional().describe('Token expiration timestamp'),
 });
 
 /**
  * Schema for restriction filters in search requests.
- * Defines the structure for inclusion/exclusion filters.
- *
- * @type {z.ZodObject}
  */
-export const RestrictionFiltersSchema = z.object({
-  datasources: z
-    .array(z.string())
-    .optional()
-    .describe('List of datasources to include/exclude'),
-  people: z
-    .array(PersonSchema)
-    .optional()
-    .describe('List of people to include/exclude'),
+const RestrictionFiltersSchema = z.object({
+  containerSpecs: z.array(DocumentSpecSchema).optional(),
+});
+
+/**
+ * Schema for search request input details.
+ */
+const SearchRequestInputDetailsSchema = z.object({
+  hasCopyPaste: z.boolean().optional(),
 });
 
 /**
  * Schema for search request options.
- * Defines the options that can be specified for a search request.
- *
- * @type {z.ZodObject}
  */
-export const SearchRequestOptionsSchema = z.object({
+const SearchRequestOptionsSchema = z.object({
   datasourceFilter: z
     .string()
     .optional()
@@ -166,14 +192,14 @@ export const SearchRequestOptionsSchema = z.object({
     .array(FacetFilterSchema)
     .optional()
     .describe('List of filters for the query (ANDed together)'),
-  facetBucketSize: z
-    .number()
-    .optional()
-    .describe('Maximum number of FacetBuckets to return in each FacetResult'),
+  facetFilterSets: z.array(FacetFilterSetSchema).optional(),
+  facetBucketFilter: FacetBucketFilterSchema.optional(),
+  facetBucketSize: z.number(),
   defaultFacets: z
     .array(z.string())
     .optional()
     .describe('Facets for which FacetResults should be fetched'),
+  authTokens: z.array(AuthTokenSchema).optional(),
   fetchAllDatasourceCounts: z
     .boolean()
     .optional()
@@ -215,23 +241,7 @@ export const SearchRequestOptionsSchema = z.object({
 });
 
 /**
- * Schema for search request input details.
- * Defines additional metadata about the search input.
- *
- * @type {z.ZodObject}
- */
-export const SearchRequestInputDetailsSchema = z.object({
-  hasCopyPaste: z
-    .boolean()
-    .optional()
-    .describe('Whether the query was at least partially copy-pasted'),
-});
-
-/**
  * Schema for search request parameters.
- * Defines all possible search parameters supported by the Glean search API.
- *
- * @type {z.ZodObject}
  */
 export const SearchSchema = z.object({
   query: z.string().describe('The search terms'),


### PR DESCRIPTION
## Description

Updates Zod schemas to use full type definitions.

## Motivation and Context

A number of the Zod schemas defined initially were underspecified, meaning that they at times defined a schema property as an `Any` type. This resulted in an underspecified JSON schema when converting the Zod schemas to the required `inputSchema` that the MCP tool requires. Using this underspecified schema in the MCP tool in combination with the OpenAI Agent's SDK resulted in errors, specifically around the fact that the schema types weren't correctly or fully defined JSON schemas. This change addresses this by ensuring we have full schemas defined (using `openai-zod-client` to generate the schemas in full).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):

## How Has This Been Tested?

- [x] Unit tests - added some schema validation tests
- [ ] Integration tests
- [x] Manual testing (with OpenAI's Agent SDK)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] I have checked for potential breaking changes and addressed them
