### PR TITLE
feat: Add error codes

### DIFF
--- a/src/auth/error.ts
+++ b/src/auth/error.ts
@@ -1,3 +1,40 @@
+export enum AuthErrorCode {
+  /** Unknown error */
+  Unknown = 'ERR_A_00',
+  /** Using glean-token config for OAuth flow */
+  GleanTokenConfigUsedForOAuth = 'ERR_A_01',
+  /** Network error fetching OAuth authorization server metadata */
+  AuthServerMetadataNetwork = 'ERR_A_02',
+  /** Parse error in OAuth authorization server metadata */
+  AuthServerMetadataParse = 'ERR_A_03',
+  /** Token endpoint missing in OAuth server metadata */
+  AuthServerMetadataMissingTokenEndpoint = 'ERR_A_04',
+  /** Device authorization endpoint missing in OAuth server metadata */
+  AuthServerMetadataMissingDeviceEndpoint = 'ERR_A_05',
+  /** Network error fetching OAuth protected resource metadata */
+  ProtectedResourceMetadataNetwork = 'ERR_A_06',
+  /** Non-ok response fetching OAuth protected resource metadata */
+  ProtectedResourceMetadataNotOk = 'ERR_A_07',
+  /** Parse error in OAuth protected resource metadata */
+  ProtectedResourceMetadataParse = 'ERR_A_08',
+  /** Authorization servers missing in OAuth protected resource metadata */
+  ProtectedResourceMetadataMissingAuthServers = 'ERR_A_09',
+  /** Device flow client id missing in OAuth protected resource metadata */
+  ProtectedResourceMetadataMissingClientId = 'ERR_A_10',
+  /** Tried to refresh tokens with glean-token config */
+  GleanTokenConfigUsedForOAuthRefresh = 'ERR_A_11',
+  /** No saved refresh token found */
+  RefreshTokenNotFound = 'ERR_A_12',
+  /** Refresh token property missing */
+  RefreshTokenMissing = 'ERR_A_13',
+  /** Unexpected response fetching access token */
+  UnexpectedAccessTokenResponse = 'ERR_A_14',
+  /** Server error when fetching token */
+  FetchTokenServerError = 'ERR_A_15',
+  /** Unexpected error requesting authorization grant */
+  UnexpectedAuthGrantError = 'ERR_A_16',
+}
+
 /**
  * AuthError is an error that will be shown to the end user (with a message, no
  * stack trace).
@@ -5,11 +42,17 @@
  * If AuthError is caught it should be re-thrown directly.
  */
 export class AuthError extends Error {
-  constructor(message: string, options = {}) {
-    super(message, options);
-    
+  public code: AuthErrorCode;
+
+  constructor(
+    message: string,
+    options: { code?: AuthErrorCode; cause?: unknown } = {},
+  ) {
+    const code = options.code ?? AuthErrorCode.Unknown;
+    const { cause } = options;
+    super(`${code}: ${message}`, cause !== undefined ? { cause } : undefined);
+    this.code = code;
     this.name = 'AuthError';
-    
     Error.captureStackTrace(this, this.constructor);
   }
 }

--- a/src/test/auth/auth.test.ts
+++ b/src/test/auth/auth.test.ts
@@ -236,7 +236,7 @@ describe('forceRefreshTokens', () => {
     loadTokensSpy.mockReturnValue(null);
     const { forceRefreshTokens } = authModule;
     await expect(forceRefreshTokens()).rejects.toThrow(
-      'Cannot refresh: unable to locate refresh token.',
+      'ERR_A_12: Cannot refresh: unable to locate refresh token.',
     );
   });
 
@@ -244,7 +244,7 @@ describe('forceRefreshTokens', () => {
     loadTokensSpy.mockReturnValue({ ...validTokens, refreshToken: undefined });
     const { forceRefreshTokens } = authModule;
     await expect(forceRefreshTokens()).rejects.toThrow(
-      'Cannot refresh: no refresh token provided.',
+      'ERR_A_13: Cannot refresh: no refresh token provided.',
     );
   });
 
@@ -257,7 +257,7 @@ describe('forceRefreshTokens', () => {
     );
     const { forceRefreshTokens } = authModule;
     await expect(forceRefreshTokens()).rejects.toThrow(
-      /Unable to fetch token. {2}Server responded 400: invalid_grant/,
+      /ERR_A_15: Unable to fetch token/,
     );
   });
 
@@ -269,7 +269,7 @@ describe('forceRefreshTokens', () => {
     });
     const { forceRefreshTokens } = authModule;
     await expect(forceRefreshTokens()).rejects.toThrow(
-      /Cannot refresh OAuth access token when using glean-token configuration/,
+      /ERR_A_11: Cannot refresh OAuth access token when using glean-token configuration/,
     );
   });
 });
@@ -360,7 +360,7 @@ describe('validateAuthorization', () => {
     loadTokensSpy.mockReturnValue(expiredTokensNoRefresh);
     const { ensureAuthTokenPresence: validateAuthorization } = authModule;
     await expect(validateAuthorization()).rejects.toThrow(
-      'Cannot refresh: no refresh token provided.',
+      'ERR_A_13: Cannot refresh: no refresh token provided.',
     );
   });
 });

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -726,7 +726,7 @@ describe('CLI', () => {
         normalizeOutput(result.stdout, project.baseDir),
       ).toMatchInlineSnapshot(`""`);
       expect(normalizeOutput(result.stderr, project.baseDir))
-        .toMatchInlineSnapshot(`"Authorization failed: Unable to fetch OAuth protected resource metadata: please contact your Glean administrator and ensure device flow authorization is configured correctly."`);
+        .toMatchInlineSnapshot(`"Authorization failed: ERR_A_06: Unable to fetch OAuth protected resource metadata: please contact your Glean administrator and ensure device flow authorization is configured correctly."`);
     });
   });
 });


### PR DESCRIPTION

## Description

<!-- Provide a brief summary of the changes in this pull request -->
AuthError now has codes that indicate the specific failure.  The codes are printed as part of the message to the user, e.g.

```
Authorization failed: ERR_A_06: Unable to fetch OAuth protected resource metadata: please contact your Glean administrator and ensure device flow authorization is configured correctly.
```

Fast follow to #48.

## Related Issue

<!-- Link to the issue this PR addresses using the syntax: Fixes #issue_number -->

Fixes #

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## Type of Change

<!-- Please check the options that are relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):

## How Has This Been Tested?

<!-- Please describe the tests you've added or the tests that verify this change works correctly -->

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] Other (please describe):

## Checklist

<!-- Please check all that apply -->

- [ ] My code follows the code style of this project
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have checked for potential breaking changes and addressed them

## Screenshots (if appropriate)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Any other information that is important to this PR -->
