### PR TITLE
feat: Polling times out after 10m

### DIFF
--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -374,7 +374,20 @@ async function pollForToken(
   config: GleanOAuthConfig,
 ): Promise<TokenResponse> {
   return new Promise((resolve, reject) => {
+    const timeoutMs = 10 * 60 * 1000; // 10 minutes
+    const startTime = Date.now();
+
     const poll = async () => {
+      const now = Date.now();
+      if (now - startTime >= timeoutMs) {
+        reject(
+          new AuthError(
+            'OAuth device flow timed out after 10 minutes. Please try again.',
+            { code: AuthErrorCode.OAuthPollingTimeout },
+          ),
+        );
+        return;
+      }
       // e.g. https://authorization-server/token
       const url = config.tokenEndpoint;
       const params = new URLSearchParams();

--- a/src/auth/error.ts
+++ b/src/auth/error.ts
@@ -33,6 +33,8 @@ export enum AuthErrorCode {
   FetchTokenServerError = 'ERR_A_15',
   /** Unexpected error requesting authorization grant */
   UnexpectedAuthGrantError = 'ERR_A_16',
+  /** Timed out waiting for OAuth device flow polling */
+  OAuthPollingTimeout = 'ERR_A_17',
 }
 
 /**


### PR DESCRIPTION
## Description

When polling for authorization grants, time out after 10 minutes.

10m is hardcoded but we can add a command-line flag later if need be.

<!-- Provide a brief summary of the changes in this pull request -->

## Related Issue

<!-- Link to the issue this PR addresses using the syntax: Fixes #issue_number -->

Fixes #

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## Type of Change

<!-- Please check the options that are relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):

## How Has This Been Tested?

<!-- Please describe the tests you've added or the tests that verify this change works correctly -->

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] Other (please describe):

## Checklist

<!-- Please check all that apply -->

- [ ] My code follows the code style of this project
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have checked for potential breaking changes and addressed them

## Screenshots (if appropriate)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Any other information that is important to this PR -->
