### PR TITLE
feat(auth): Support verification_url

### DIFF
--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -13,6 +13,7 @@ import { loadTokens, saveTokens, Tokens } from './token-store.js';
 import {
   AuthResponse,
   isAuthResponse,
+  isAuthResponseWithURL,
   isTokenSuccess,
   TokenError,
   TokenResponse,
@@ -450,7 +451,7 @@ async function getConfigAndUpgradeToOAuth(): Promise<
   return config;
 }
 
-async function fetchDeviceAuthorization(
+export async function fetchDeviceAuthorization(
   config: GleanOAuthConfig,
 ): Promise<AuthResponse> {
   const params = new URLSearchParams();
@@ -473,9 +474,32 @@ async function fetchDeviceAuthorization(
   const response = await fetch(url, options);
   const responseJson = await response.json();
 
-  if (!isAuthResponse(responseJson)) {
-    throw [response, responseJson];
+  if (
+    !(
+      response.ok &&
+      responseJson !== undefined &&
+      typeof responseJson === 'object'
+    )
+  ) {
+    throw new AuthError('Error obtaining auth grant', {
+      code: AuthErrorCode.UnexpectedAuthGrantError,
+      cause: new Error(
+        JSON.stringify({ status: response.status, body: responseJson }),
+      ),
+    });
   }
 
-  return responseJson;
+  const result = { ...responseJson } as any;
+
+  if (isAuthResponseWithURL(responseJson)) {
+    result['verification_uri'] = result['verification_url'];
+    delete result['verification_url'];
+  } else if (!isAuthResponse(responseJson)) {
+    throw new AuthError('Unexpected auth grant response', {
+      code: AuthErrorCode.UnexpectedAuthGrantResponse,
+      cause: new Error(JSON.stringify(responseJson)),
+    });
+  }
+
+  return result;
 }

--- a/src/auth/error.ts
+++ b/src/auth/error.ts
@@ -39,6 +39,8 @@ export enum AuthErrorCode {
   NoInteractiveTerminal = 'ERR_A_18',
   /** Invalid or missing Glean configuration */
   InvalidConfig = 'ERR_A_19',
+  /** Unexpected response fetching access token */
+  UnexpectedAuthGrantResponse = 'ERR_A_20',
 }
 
 /**

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -39,8 +39,11 @@ export interface AuthResponse {
   interval: number;
 }
 
+export type AuthResponseWithURL = Omit<AuthResponse, 'verification_uri'> & {
+  verification_url: string;
+};
+
 export function isTokenSuccess(json: any): json is TokenResponse {
-  // TODO:: here we go
   return (
     json !== undefined &&
     typeof json === 'object' &&
@@ -50,12 +53,18 @@ export function isTokenSuccess(json: any): json is TokenResponse {
 }
 
 export function isAuthResponse(json: any): json is AuthResponse {
+  return hasCommonAuthResponseFields(json) && 'verification_uri' in json;
+}
+export function isAuthResponseWithURL(json: any): json is AuthResponseWithURL {
+  return hasCommonAuthResponseFields(json) && 'verification_url' in json;
+}
+
+function hasCommonAuthResponseFields(json: any): boolean {
   return (
     json !== undefined &&
     typeof json === 'object' &&
     'device_code' in json &&
     'user_code' in json &&
-    'verification_uri' in json &&
     'expires_in' in json &&
     'interval' in json
   );


### PR DESCRIPTION

## Description

RFC 8628§3.2 describes a device authorization response as containing `verification_uri` but some providers like `url` more than the spec.

Normalize the response to support both.
<!-- Provide a brief summary of the changes in this pull request -->

## Related Issue

<!-- Link to the issue this PR addresses using the syntax: Fixes #issue_number -->

Fixes #

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## Type of Change

<!-- Please check the options that are relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):

## How Has This Been Tested?

<!-- Please describe the tests you've added or the tests that verify this change works correctly -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] Other (please describe):

## Checklist

<!-- Please check all that apply -->

- [ ] My code follows the code style of this project
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have checked for potential breaking changes and addressed them

## Screenshots (if appropriate)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Any other information that is important to this PR -->
