### PR TITLE
feat(auth): prefer openid-configuration

### DIFF
--- a/src/test/auth/authorize.test.ts
+++ b/src/test/auth/authorize.test.ts
@@ -125,7 +125,7 @@ describe('authorize (device flow)', () => {
         }),
       ),
       // 2. Mock authorization server metadata
-      http.get(`${issuer}/.well-known/oauth-authorization-server`, () =>
+      http.get(`${issuer}/.well-known/openid-configuration`, () =>
         HttpResponse.json({
           device_authorization_endpoint: deviceAuthorizationEndpoint,
           token_endpoint: tokenEndpoint,
@@ -215,7 +215,7 @@ describe('authorize (device flow)', () => {
         }),
       ),
       // Mock authorization server metadata to fail
-      http.get(`${issuer}/.well-known/oauth-authorization-server`, () =>
+      http.get(`${issuer}/.well-known/openid-configuration`, () =>
         HttpResponse.error(),
       ),
     );
@@ -240,7 +240,7 @@ describe('authorize (device flow)', () => {
         }),
       ),
       // Mock authorization server metadata to succeed
-      http.get(`${issuer}/.well-known/oauth-authorization-server`, () =>
+      http.get(`${issuer}/.well-known/openid-configuration`, () =>
         HttpResponse.json({
           device_authorization_endpoint: deviceAuthorizationEndpoint,
           token_endpoint: tokenEndpoint,
@@ -274,7 +274,7 @@ describe('authorize (device flow)', () => {
         }),
       ),
       // Mock authorization server metadata to succeed
-      http.get(`${issuer}/.well-known/oauth-authorization-server`, () =>
+      http.get(`${issuer}/.well-known/openid-configuration`, () =>
         HttpResponse.json({
           device_authorization_endpoint: deviceAuthorizationEndpoint,
           token_endpoint: tokenEndpoint,
@@ -335,7 +335,7 @@ describe('authorize (device flow)', () => {
         }),
       ),
       // Mock authorization server metadata to succeed
-      http.get(`${issuer}/.well-known/oauth-authorization-server`, () =>
+      http.get(`${issuer}/.well-known/openid-configuration`, () =>
         HttpResponse.json({
           device_authorization_endpoint: deviceAuthorizationEndpoint,
           token_endpoint: tokenEndpoint,
@@ -413,7 +413,7 @@ describe('authorize (device flow)', () => {
         }),
       ),
       // Mock authorization server metadata to succeed
-      http.get(`${issuer}/.well-known/oauth-authorization-server`, () =>
+      http.get(`${issuer}/.well-known/openid-configuration`, () =>
         HttpResponse.json({
           device_authorization_endpoint: deviceAuthorizationEndpoint,
           token_endpoint: tokenEndpoint,
@@ -486,7 +486,7 @@ describe('authorize (device flow)', () => {
           glean_device_flow_client_id: clientId,
         }),
       ),
-      http.get(`${issuer}/.well-known/oauth-authorization-server`, () =>
+      http.get(`${issuer}/.well-known/openid-configuration`, () =>
         HttpResponse.json({
           device_authorization_endpoint: deviceAuthorizationEndpoint,
           token_endpoint: tokenEndpoint,


### PR DESCRIPTION

## Description
We can get token and authorization endpoints from either openid-configuration or oauth-resource-metadata.  The former is newer and better supported.

Still keeping oauth-resource-metadata as a fallback.

<!-- Provide a brief summary of the changes in this pull request -->

## Related Issue

<!-- Link to the issue this PR addresses using the syntax: Fixes #issue_number -->

Fixes #

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## Type of Change

<!-- Please check the options that are relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):

## How Has This Been Tested?

<!-- Please describe the tests you've added or the tests that verify this change works correctly -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] Other (please describe):

## Checklist

<!-- Please check all that apply -->

- [ ] My code follows the code style of this project
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have checked for potential breaking changes and addressed them

## Screenshots (if appropriate)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Any other information that is important to this PR -->
