### PR TITLE
fix(auth): token poller

### DIFF
--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -336,12 +336,18 @@ async function authorize(config: GleanOAuthConfig): Promise<Tokens | null> {
     );
   }
 
+  let cause: any = undefined;
   try {
     const authResponse = await fetchDeviceAuthorization(config);
-    const tokenPoller = pollForToken(authResponse, config);
+    const tokenPoller = pollForToken(authResponse, config).catch((e) => {
+      cause = e;
+    });
     await promptUserAndOpenVerificationPage(authResponse);
     const tokenResponse = await tokenPoller;
-    return Tokens.buildFromTokenResponse(tokenResponse);
+    if (cause !== undefined) {
+      throw cause;
+    }
+    return Tokens.buildFromTokenResponse(tokenResponse as TokenResponse);
   } catch (cause: any) {
     if (cause instanceof AuthError) {
       throw cause;

--- a/src/test/auth/authorize.test.ts
+++ b/src/test/auth/authorize.test.ts
@@ -514,4 +514,66 @@ describe('authorize (device flow)', () => {
       });
     }
   });
+
+  it('should throw with correct message if token poller rejects immediately', async () => {
+    const baseUrl = 'https://glean.example.com';
+    const issuer = 'https://auth.example.com';
+    const clientId = 'client-123';
+    const deviceAuthorizationEndpoint = 'https://auth.example.com/device';
+    const tokenEndpoint = 'https://auth.example.com/token';
+    const deviceCode = 'device-code-abc';
+    const userCode = 'user-code-xyz';
+    const verificationUri = 'https://auth.example.com/verify';
+    const interval = 5;
+    // Mock protected resource metadata to succeed
+    server.use(
+      http.get(`${baseUrl}/.well-known/oauth-protected-resource`, () =>
+        HttpResponse.json({
+          authorization_servers: [issuer],
+          glean_device_flow_client_id: clientId,
+        }),
+      ),
+      // Mock authorization server metadata to succeed
+      http.get(`${issuer}/.well-known/oauth-authorization-server`, () =>
+        HttpResponse.json({
+          device_authorization_endpoint: deviceAuthorizationEndpoint,
+          token_endpoint: tokenEndpoint,
+        }),
+      ),
+      // Mock device authorization endpoint to succeed
+      http.post(deviceAuthorizationEndpoint, () =>
+        HttpResponse.json({
+          device_code: deviceCode,
+          user_code: userCode,
+          verification_uri: verificationUri,
+          expires_in: 600,
+          interval,
+        }),
+      ),
+      // Mock token polling endpoint to immediately return an error
+      http.post(tokenEndpoint, async ({ request }) => {
+        const body = await request.text();
+        if (body.includes(`device_code=${deviceCode}`)) {
+          // Ensure we error on the very first request from the poller, so that
+          // the promise rejects before we `await tokenPoller`.  Verifying that
+          // this errors correctly is the whole point of this test.
+          return HttpResponse.json(
+            {
+              error: 'invalid_grant',
+              error_description: 'The device code is invalid',
+            },
+            { status: 400 },
+          );
+        }
+        return HttpResponse.json({
+          error: 'authorization_pending',
+          error_description: 'pending',
+        });
+      }),
+    );
+    // Act & Assert
+    await expect(forceAuthorize()).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[AuthError: ERR_A_16: Unexpected error requesting authorization grant]`,
+    );
+  });
 });


### PR DESCRIPTION

## Description

Previously we would fail gracelessly in the case where the token poller rejected on the first very request, i.e. before we awaited the tokenPoller (and therefore had a reject handler attached).
<!-- Provide a brief summary of the changes in this pull request -->

## Related Issue

<!-- Link to the issue this PR addresses using the syntax: Fixes #issue_number -->

Fixes #

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## Type of Change

<!-- Please check the options that are relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):

## How Has This Been Tested?

<!-- Please describe the tests you've added or the tests that verify this change works correctly -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] Other (please describe):

## Checklist

<!-- Please check all that apply -->

- [ ] My code follows the code style of this project
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have checked for potential breaking changes and addressed them

## Screenshots (if appropriate)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Any other information that is important to this PR -->
