### PR TITLE
task: Simplifies schemas to provide a more consistent tool invocation

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -66,10 +66,10 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
 
         {
             "query": "What are the company holidays this year?",
-            "pageSize": 10
+            "datasources": ["drive", "confluence"]
         }
         `,
-        inputSchema: zodToJsonSchema(search.SearchSchema),
+        inputSchema: zodToJsonSchema(search.ToolSearchSchema),
       },
       {
         name: TOOL_NAMES.chat,
@@ -78,20 +78,14 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         Example request:
 
         {
-            "messages": [
-                {
-                    "author": "USER",
-                    "messageType": "CONTENT",
-                    "fragments": [
-                        {
-                            "text": "What are the company holidays this year?"
-                        }
-                    ]
-                }
+            "message": "What are the company holidays this year?",
+            "context": [
+                "Hello, I need some information about time off.",
+                "I'm planning my vacation for next year."
             ]
         }
         `,
-        inputSchema: zodToJsonSchema(chat.ChatSchema),
+        inputSchema: zodToJsonSchema(chat.ToolChatSchema),
       },
     ],
   };
@@ -117,7 +111,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     switch (request.params.name) {
       case TOOL_NAMES.search: {
-        const args = search.SearchSchema.parse(request.params.arguments);
+        const args = search.ToolSearchSchema.parse(request.params.arguments);
         const result = await search.search(args);
         const formattedResults = search.formatResponse(result);
 
@@ -128,7 +122,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case TOOL_NAMES.chat: {
-        const args = chat.ChatSchema.parse(request.params.arguments);
+        const args = chat.ToolChatSchema.parse(request.params.arguments);
         const response = await chat.chat(args);
         const formattedResponse = chat.formatResponse(response);
 

--- a/src/tools/chat.ts
+++ b/src/tools/chat.ts
@@ -27,7 +27,7 @@ export type ToolChatRequest = z.infer<typeof ToolChatSchema>;
  * @param input Simplified chat request parameters
  * @returns Glean API compatible chat request
  */
-function mapChatRequest(input: ToolChatRequest) {
+function convertToAPIChatRequest(input: ToolChatRequest) {
   const { message, context = [] } = input;
 
   const messages = [
@@ -59,7 +59,7 @@ function mapChatRequest(input: ToolChatRequest) {
  * @throws If the chat request fails
  */
 export async function chat(params: ToolChatRequest) {
-  const mappedParams = mapChatRequest(params);
+  const mappedParams = convertToAPIChatRequest(params);
   const parsedParams = ChatRequestSchema.parse(mappedParams);
   const client = await getClient();
 

--- a/src/tools/chat.ts
+++ b/src/tools/chat.ts
@@ -1,17 +1,66 @@
 import { z } from 'zod';
 import { getClient } from '../common/client.js';
 import { ChatRequest$inboundSchema as ChatRequestSchema } from '@gleanwork/api-client/models/components';
+import { Author } from '@gleanwork/api-client/models/components';
 
-export const ChatSchema = ChatRequestSchema;
+/**
+ * Simplified schema for Glean chat requests designed for LLM interaction
+ */
+export const ToolChatSchema = z.object({
+  message: z
+    .string()
+    .describe('The user question or message to send to Glean Assistant.'),
+
+  context: z
+    .array(z.string())
+    .describe(
+      'Optional previous messages for context. Will be included in order before the current message.',
+    )
+    .optional(),
+});
+
+export type ToolChatRequest = z.infer<typeof ToolChatSchema>;
+
+/**
+ * Maps a simplified chat request to the format expected by the Glean API.
+ *
+ * @param input Simplified chat request parameters
+ * @returns Glean API compatible chat request
+ */
+function mapChatRequest(input: ToolChatRequest) {
+  const { message, context = [] } = input;
+
+  const messages = [
+    ...context.map((text) => ({
+      author: Author.User,
+      messageType: 'CONTENT',
+      fragments: [{ text }],
+    })),
+
+    {
+      author: Author.User,
+      messageType: 'CONTENT',
+      fragments: [{ text: message }],
+    },
+  ];
+
+  const chatRequest = {
+    messages,
+  };
+
+  return chatRequest;
+}
+
 /**
  * Initiates or continues a chat conversation with Glean's AI.
  *
- * @param params The chat parameters
+ * @param params The chat parameters using the simplified schema
  * @returns The chat response
  * @throws If the chat request fails
  */
-export async function chat(params: z.infer<typeof ChatRequestSchema>) {
-  const parsedParams = ChatRequestSchema.parse(params);
+export async function chat(params: ToolChatRequest) {
+  const mappedParams = mapChatRequest(params);
+  const parsedParams = ChatRequestSchema.parse(mappedParams);
   const client = await getClient();
 
   return await client.chat.create(parsedParams);

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -12,19 +12,65 @@ import { z } from 'zod';
 import { getClient } from '../common/client.js';
 import { SearchRequest$inboundSchema as SearchRequestSchema } from '@gleanwork/api-client/models/components';
 
-export const SearchSchema = SearchRequestSchema;
+/**
+ * Simplified schema for Glean search requests designed for LLM interaction
+ */
+export const ToolSearchSchema = z.object({
+  query: z
+    .string()
+    .describe('The search query. This is what you want to search for.'),
+
+  datasources: z
+    .array(z.string())
+    .describe(
+      'Optional list of data sources to search in. Examples: "github", "gdrive", "confluence", "jira".',
+    )
+    .optional(),
+});
+
+export type ToolSearchRequest = z.infer<typeof ToolSearchSchema>;
+
+/**
+ * Maps a simplified search request to the format expected by the Glean API.
+ *
+ * @param input Simplified search request parameters
+ * @returns Glean API compatible search request
+ */
+function mapSearchRequest(input: ToolSearchRequest) {
+  const { query, datasources } = input;
+
+  // Initialize request object with fixed page size
+  const searchRequest: any = {
+    query,
+    pageSize: 10, // Fixed default page size
+  };
+
+  // Map datasources to datasourcesFilter if provided
+  if (datasources && datasources.length > 0) {
+    searchRequest.requestOptions = {
+      datasourcesFilter: datasources,
+    };
+  }
+
+  return searchRequest;
+}
 
 /**
  * Executes a search query against Glean's content index.
  *
- * @param params The search parameters
+ * @param params The search parameters using the simplified schema
  * @returns The search results
  * @throws If the search request fails
  */
-export async function search(params: z.infer<typeof SearchRequestSchema>) {
-  const parsedParams = SearchRequestSchema.parse(params);
-  const client = await getClient();
+export async function search(params: ToolSearchRequest) {
+  // Map simplified params to the format expected by the Glean API
+  const mappedParams = mapSearchRequest(params);
 
+  // Validate with the original schema to ensure compatibility
+  const parsedParams = SearchRequestSchema.parse(mappedParams);
+
+  // Get client and execute request
+  const client = await getClient();
   return await client.search.query(parsedParams);
 }
 

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -36,7 +36,7 @@ export type ToolSearchRequest = z.infer<typeof ToolSearchSchema>;
  * @param input Simplified search request parameters
  * @returns Glean API compatible search request
  */
-function mapSearchRequest(input: ToolSearchRequest) {
+function convertToAPISearchRequest(input: ToolSearchRequest) {
   const { query, datasources } = input;
 
   // Initialize request object with fixed page size
@@ -64,7 +64,7 @@ function mapSearchRequest(input: ToolSearchRequest) {
  */
 export async function search(params: ToolSearchRequest) {
   // Map simplified params to the format expected by the Glean API
-  const mappedParams = mapSearchRequest(params);
+  const mappedParams = convertToAPISearchRequest(params);
 
   // Validate with the original schema to ensure compatibility
   const parsedParams = SearchRequestSchema.parse(mappedParams);


### PR DESCRIPTION
## Description

The current implementation uses the raw schemas from both the `/search` and `/chat` endpoints. These don't work well as MCP tools, since the schemas are vastly more complex than an LLM can understand, and it really struggles to formulate coherent requests.

This change introduces new simplified schemas instead. These schemas are more LLM friendly, and allow for a higher probability that the tool will be able to be understood and invoked. We take these new tool requests and map them to the API requests that are passed through to the client, and hence provide the clean mapping between tool request and API request.

## Related Issue

Fixes #80 
Fixes #83 

## Type of Change

<!-- Please check the options that are relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):

## How Has This Been Tested?

<!-- Please describe the tests you've added or the tests that verify this change works correctly -->

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing
- [ ] Other (please describe):