### PR TITLE
chore: Bumping node, pinning to lowest version, updating ci matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
     env:
       VOLTA_FEATURE_PNPM: 1
     steps:

--- a/package.json
+++ b/package.json
@@ -74,10 +74,10 @@
     "vitest": "^3.0.9"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "volta": {
-    "node": "22.14.0",
+    "node": "20.19.1",
     "pnpm": "10.6.2"
   },
   "publishConfig": {


### PR DESCRIPTION
## Description

Updated the CI configuration to support Node.js versions 20.x, 22.x, and added 24.x, while pinning the package engine minimum Node.js version to 20. 

## Type of Change

<!-- Please check the options that are relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):

## How Has This Been Tested?

<!-- Please describe the tests you've added or the tests that verify this change works correctly -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] Other (please describe):

## Checklist

<!-- Please check all that apply -->

- [ ] My code follows the code style of this project
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have checked for potential breaking changes and addressed them

## Screenshots (if appropriate)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Any other information that is important to this PR -->
