### PR TITLE
feat(cli): add explicit 'server' command as default

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -109,9 +109,11 @@ async function main() {
       Typically this package is configured in an MCP client configuration file.
       However, you can also run it directly with the following commands, which help you set up the server configuration in an MCP client:
 
+      $ npx @gleanwork/mcp-server [server]                           # Run the MCP server (default)
       $ npx @gleanwork/mcp-server configure --client <client-name> [options]
 
     Commands
+      server      Run the MCP server (default if no command is specified)
       configure   Configure MCP settings for a specific client/host
       help        Show this help message
 
@@ -174,18 +176,17 @@ async function main() {
   trace(process.title, `ppid/pid: [${process.ppid} / ${process.pid}]`);
   trace(process.execPath, process.execArgv, process.argv);
 
-  // If no input is provided, run the MCP server
-  if (cli.input.length === 0) {
-    runServer().catch((error) => {
-      console.error('Error starting MCP server:', error);
-      process.exit(1);
-    });
-    return;
-  }
-
-  const command = cli.input[0].toLowerCase();
+  // Get the command, defaulting to 'server' if none provided
+  const command = cli.input.length === 0 ? 'server' : cli.input[0].toLowerCase();
 
   switch (command) {
+    case 'server': {
+      runServer().catch((error) => {
+        console.error('Error starting MCP server:', error);
+        process.exit(1);
+      });
+      return;
+    }
     case 'configure': {
       const { client, token, instance, url, env } = cli.flags;
 

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -58,9 +58,11 @@ describe('CLI', () => {
             Typically this package is configured in an MCP client configuration file.
             However, you can also run it directly with the following commands, which help you set up the server configuration in an MCP client:
 
+            $ npx @gleanwork/mcp-server [server]                           # Run the MCP server (default)
             $ npx @gleanwork/mcp-server configure --client <client-name> [options]
 
           Commands
+            server      Run the MCP server (default if no command is specified)
             configure   Configure MCP settings for a specific client/host
             help        Show this help message
 


### PR DESCRIPTION
## Description

Add `npx @gleanwork/mcp-server server` subcommand. There is no functional change here (if you invoke without a subcommand we do just as before -> run the server). 

## Motivation and Context

Sets the stage for future refactorings allowing `--instance` and `--token` to be specified.

## Type of Change

<!-- Please check the options that are relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):

## How Has This Been Tested?

<!-- Please describe the tests you've added or the tests that verify this change works correctly -->

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Other (please describe):

## Checklist

<!-- Please check all that apply -->

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] I have checked for potential breaking changes and addressed them

