### PR TITLE
fix(cli): Fix short flag to `-i`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -146,7 +146,7 @@ async function main() {
         },
         instance: {
           type: 'string',
-          shortFlag: 'd',
+          shortFlag: 'i',
         },
         // Omit url from help output.  This flag is only useful for dev, when
         // you're running a local server and need to specify a port.


### PR DESCRIPTION
## Description

Fix the short flag version of `--instance` to be `-i`. The long version was changed as part of the `--domain` to `--instance` change, but the short flag was not updated (and is now mismatched with the `--help` output contents).

## Type of Change

<!-- Please check the options that are relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):

## How Has This Been Tested?

<!-- Please describe the tests you've added or the tests that verify this change works correctly -->

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Other (please describe):

## Checklist

<!-- Please check all that apply -->

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] I have checked for potential breaking changes and addressed them
