### PR TITLE
feat(cli): add instance and token options to server command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -109,13 +109,17 @@ async function main() {
       Typically this package is configured in an MCP client configuration file.
       However, you can also run it directly with the following commands, which help you set up the server configuration in an MCP client:
 
-      $ npx @gleanwork/mcp-server [server]                           # Run the MCP server (default)
+      $ npx @gleanwork/mcp-server [server] [options]                 # Run the MCP server (default)
       $ npx @gleanwork/mcp-server configure --client <client-name> [options]
 
     Commands
       server      Run the MCP server (default if no command is specified)
       configure   Configure MCP settings for a specific client/host
       help        Show this help message
+
+    Options for server
+      --instance, -i   Glean instance name
+      --token, -t      Glean API token
 
     Options for configure
       --client, -c   MCP client to configure for (${clientList || 'loading available clients...'})
@@ -125,6 +129,7 @@ async function main() {
 
     Examples
       $ npx @gleanwork/mcp-server
+      $ npx @gleanwork/mcp-server server --instance my-company --token glean_api_xyz
       $ npx @gleanwork/mcp-server configure --client cursor --token glean_api_xyz --instance my-company
       $ npx @gleanwork/mcp-server configure --client claude --token glean_api_xyz --instance my-company
       $ npx @gleanwork/mcp-server configure --client windsurf --env ~/.glean.env
@@ -177,11 +182,13 @@ async function main() {
   trace(process.execPath, process.execArgv, process.argv);
 
   // Get the command, defaulting to 'server' if none provided
-  const command = cli.input.length === 0 ? 'server' : cli.input[0].toLowerCase();
+  const command =
+    cli.input.length === 0 ? 'server' : cli.input[0].toLowerCase();
 
   switch (command) {
     case 'server': {
-      runServer().catch((error) => {
+      const { instance, token } = cli.flags;
+      runServer({ instance, token }).catch((error) => {
         console.error('Error starting MCP server:', error);
         process.exit(1);
       });
@@ -252,7 +259,7 @@ async function main() {
 
     case 'auth-test': {
       try {
-        const chatResponse = await chat({ message: "Who am I?" });
+        const chatResponse = await chat({ message: 'Who am I?' });
         trace('auth-test search', formatResponse(chatResponse));
         console.log('Access token accepted.');
       } catch (err: any) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -242,9 +242,24 @@ export function formatGleanError(error: GleanError): string {
  * This is the main entry point for the server process.
  *
  * @async
+ * @param {Object} options - Options for server initialization
+ * @param {string} [options.instance] - The Glean instance name from the command line
+ * @param {string} [options.token] - The Glean API token from the command line
  * @throws {Error} If server initialization or connection fails
  */
-export async function runServer() {
+export async function runServer(options?: {
+  instance?: string;
+  token?: string;
+}) {
+  // Set environment variables from command line args if provided
+  if (options?.instance) {
+    process.env.GLEAN_INSTANCE = options.instance;
+  }
+
+  if (options?.token) {
+    process.env.GLEAN_API_TOKEN = options.token;
+  }
+
   const transport = new StdioServerTransport();
 
   try {

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -58,13 +58,17 @@ describe('CLI', () => {
             Typically this package is configured in an MCP client configuration file.
             However, you can also run it directly with the following commands, which help you set up the server configuration in an MCP client:
 
-            $ npx @gleanwork/mcp-server [server]                           # Run the MCP server (default)
+            $ npx @gleanwork/mcp-server [server] [options]                 # Run the MCP server (default)
             $ npx @gleanwork/mcp-server configure --client <client-name> [options]
 
           Commands
             server      Run the MCP server (default if no command is specified)
             configure   Configure MCP settings for a specific client/host
             help        Show this help message
+
+          Options for server
+            --instance, -i   Glean instance name
+            --token, -t      Glean API token
 
           Options for configure
             --client, -c   MCP client to configure for (claude, cursor, windsurf)
@@ -74,6 +78,7 @@ describe('CLI', () => {
 
           Examples
             $ npx @gleanwork/mcp-server
+            $ npx @gleanwork/mcp-server server --instance my-company --token glean_api_xyz
             $ npx @gleanwork/mcp-server configure --client cursor --token glean_api_xyz --instance my-company
             $ npx @gleanwork/mcp-server configure --client claude --token glean_api_xyz --instance my-company
             $ npx @gleanwork/mcp-server configure --client windsurf --env ~/.glean.env


### PR DESCRIPTION
## Description

Add command line options to directly specify Glean instance and API token when running the server:

- Add `--instance` (`-i`) and `--token` (`-t`) options for server command
- Update documentation and help text to reflect new options
- Add example showing usage with new options
- Pass CLI arguments to runServer function to set environment variables

## Type of Change

<!-- Please check the options that are relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):

## How Has This Been Tested?

<!-- Please describe the tests you've added or the tests that verify this change works correctly -->

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing
- [ ] Other (please describe):

## Checklist

<!-- Please check all that apply -->

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] I have checked for potential breaking changes and addressed them
