### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 [![npm version](https://badge.fury.io/js/@gleanwork%2Fmcp-server.svg)](https://badge.fury.io/js/@gleanwork%2Fmcp-server)
 [![License](https://img.shields.io/npm/l/@gleanwork%2Fmcp-server.svg)](https://github.com/gleanwork/mcp-server/blob/main/LICENSE)
 
+<a href="https://glama.ai/mcp/servers/@gleanwork/mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@gleanwork/mcp-server/badge" alt="Glean Server MCP server" />
+</a>
+
 The Glean MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) server that provides seamless integration with Glean's enterprise knowledge.
 
 ## Features


### PR DESCRIPTION
This PR adds a badge for the [Glean MCP Server](https://glama.ai/mcp/servers/@gleanwork/mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@gleanwork/mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@gleanwork/mcp-server/badge" alt="Glean Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.