### PR TITLE
chore(dependabot): remove deprecated reviewers field

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "gleanwork/gleanwork-reviewers"


### PR DESCRIPTION
## Description

This commit removes the deprecated `reviewers` field from dependabot.yml.  According to GitHub, this field will be removed soon and repository code  owners (CODEOWNERS file) should be used instead to specify reviewers for  Dependabot PRs.

See: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

## Type of Change

<!-- Please check the options that are relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Build/CI pipeline changes
- [ ] Other (please describe):

## How Has This Been Tested?

<!-- Please describe the tests you've added or the tests that verify this change works correctly -->

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Other (please describe):

## Checklist

<!-- Please check all that apply -->

- [x] My code follows the code style of this project
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have checked for potential breaking changes and addressed them
