### PR TITLE
feat(configure): add VS Code MCP client support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ npx @gleanwork/mcp-server configure --client cursor --token your_api_token --ins
 # Configure for Claude Desktop
 npx @gleanwork/mcp-server configure --client claude --token your_api_token --instance instance_name
 
+# Configure for VS Code
+npx @gleanwork/mcp-server configure --client vscode --token your_api_token --instance instance_name
+
 # Configure for Windsurf
 npx @gleanwork/mcp-server configure --client windsurf --token your_api_token --instance instance_name
 ```

--- a/src/configure/client/vscode.ts
+++ b/src/configure/client/vscode.ts
@@ -1,0 +1,123 @@
+/**
+ * VS Code MCP Client Implementation
+ *
+ * https://code.visualstudio.com/docs/copilot/chat/mcp-servers
+ */
+
+import path from 'path';
+import { MCPConfigPath, createBaseClient } from '../index.js';
+
+// VS Code user settings location varies by platform
+function getVSCodeUserSettingsPath(homedir: string): string {
+  // Windows: %APPDATA%\Code\User\settings.json
+  // macOS: ~/Library/Application Support/Code/User/settings.json
+  // Linux: ~/.config/Code/User/settings.json
+  const platform = process.platform;
+
+  if (platform === 'win32') {
+    return path.join(
+      process.env.APPDATA || '',
+      'Code',
+      'User',
+      'settings.json',
+    );
+  } else if (platform === 'darwin') {
+    return path.join(
+      homedir,
+      'Library',
+      'Application Support',
+      'Code',
+      'User',
+      'settings.json',
+    );
+  } else {
+    // Linux or other platforms
+    return path.join(homedir, '.config', 'Code', 'User', 'settings.json');
+  }
+}
+
+export const vscodeConfigPath: MCPConfigPath = {
+  configDir: '',
+  configFileName: '',
+};
+
+const vscodeClient = createBaseClient('VS Code', vscodeConfigPath, [
+  'Enable MCP support in VS Code by adding "chat.mcp.enabled": true to your user settings',
+  'Restart VS Code',
+  'Open the Chat view (Ctrl+Alt+I or ⌃⌘I) and select "Agent" mode from the dropdown',
+  'Click the "Tools" button to see and use Glean tools in Agent mode',
+  "You'll be asked for approval when Agent uses these tools",
+]);
+
+vscodeClient.configFilePath = (homedir: string) => {
+  return getVSCodeUserSettingsPath(homedir);
+};
+
+vscodeClient.successMessage = (configPath) => `
+VS Code MCP configuration has been configured in your user settings: ${configPath}
+
+To use it:
+1. Enable MCP support in VS Code by adding "chat.mcp.enabled": true to your user settings
+2. Restart VS Code
+3. Open the Chat view (Ctrl+Alt+I or ⌃⌘I) and select "Agent" mode from the dropdown
+4. Click the "Tools" button to see and use Glean tools in Agent mode
+5. You'll be asked for approval when Agent uses these tools
+
+Notes:
+- You may need to set your Glean instance and API token if they weren't provided during configuration
+- User settings are at: ${configPath}
+`;
+
+vscodeClient.configTemplate = (instanceOrUrl?: string, apiToken?: string) => {
+  const env: Record<string, string> = {};
+
+  // If it looks like a URL, use GLEAN_BASE_URL
+  if (
+    instanceOrUrl?.startsWith('http://') ||
+    instanceOrUrl?.startsWith('https://')
+  ) {
+    const baseUrl = instanceOrUrl.endsWith('/rest/api/v1')
+      ? instanceOrUrl
+      : `${instanceOrUrl}/rest/api/v1`;
+    env.GLEAN_BASE_URL = baseUrl;
+  } else if (instanceOrUrl) {
+    env.GLEAN_INSTANCE = instanceOrUrl;
+  }
+
+  if (apiToken) {
+    env.GLEAN_API_TOKEN = apiToken;
+  }
+
+  return {
+    mcp: {
+      servers: {
+        glean: {
+          type: 'stdio',
+          command: 'npx',
+          args: ['-y', '@gleanwork/mcp-server'],
+          env: env,
+        },
+      },
+    },
+  };
+};
+
+vscodeClient.hasExistingConfig = (existingConfig: Record<string, any>) => {
+  return (
+    existingConfig.mcp?.servers?.glean?.command === 'npx' &&
+    existingConfig.mcp?.servers?.glean?.args?.includes('@gleanwork/mcp-server')
+  );
+};
+
+vscodeClient.updateConfig = (
+  existingConfig: Record<string, any>,
+  newConfig: any,
+) => {
+  existingConfig.mcp = existingConfig.mcp || {};
+  existingConfig.mcp.servers = existingConfig.mcp.servers || {};
+  existingConfig.mcp.servers.glean = newConfig.mcp.servers.glean;
+  return existingConfig;
+};
+
+export default vscodeClient;
+

--- a/src/configure/index.ts
+++ b/src/configure/index.ts
@@ -34,6 +34,24 @@ export interface MCPClientConfig {
 
   /** Instructions displayed after successful configuration */
   successMessage: (configPath: string) => string;
+
+  /**
+   * Check if configuration exists in the existing config object
+   * @param existingConfig Existing configuration object from the config file
+   * @returns boolean indicating if configuration exists
+   */
+  hasExistingConfig: (existingConfig: Record<string, any>) => boolean;
+
+  /**
+   * Update existing configuration with new config
+   * @param existingConfig Existing configuration object to update
+   * @param newConfig New configuration to merge with existing
+   * @returns Updated configuration object
+   */
+  updateConfig: (
+    existingConfig: Record<string, any>,
+    newConfig: any,
+  ) => Record<string, any>;
 }
 
 /**
@@ -123,6 +141,21 @@ export function createBaseClient(
 
     successMessage: (configPath) =>
       createSuccessMessage(displayName, configPath, instructions),
+
+    hasExistingConfig: (existingConfig: Record<string, any>) => {
+      return (
+        existingConfig.mcpServers?.glean?.command === 'npx' &&
+        existingConfig.mcpServers?.glean?.args?.includes(
+          '@gleanwork/mcp-server',
+        )
+      );
+    },
+
+    updateConfig: (existingConfig: Record<string, any>, newConfig: any) => {
+      existingConfig.mcpServers = existingConfig.mcpServers || {};
+      existingConfig.mcpServers.glean = newConfig.mcpServers.glean;
+      return existingConfig;
+    },
   };
 }
 

--- a/src/test/configure/vscode.test.ts
+++ b/src/test/configure/vscode.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import vscodeClient from '../../configure/client/vscode.js';
+import os from 'os';
+import path from 'path';
+
+describe('VS Code MCP Client', () => {
+  it('should have the correct display name', () => {
+    expect(vscodeClient.displayName).toBe('VS Code');
+  });
+
+  it('should generate the correct config path based on platform', () => {
+    const homedir = os.homedir();
+    const platform = process.platform;
+    let expectedPath: string;
+    
+    if (platform === 'win32') {
+      expectedPath = path.join(process.env.APPDATA || '', 'Code', 'User', 'settings.json');
+    } else if (platform === 'darwin') {
+      expectedPath = path.join(homedir, 'Library', 'Application Support', 'Code', 'User', 'settings.json');
+    } else {
+      // Linux or other platforms
+      expectedPath = path.join(homedir, '.config', 'Code', 'User', 'settings.json');
+    }
+    
+    expect(vscodeClient.configFilePath(homedir)).toBe(expectedPath);
+  });
+
+  it('should generate a valid VS Code MCP config template with instance', () => {
+    const config = vscodeClient.configTemplate('example-instance', 'test-token');
+    expect(config).toMatchInlineSnapshot(`
+      {
+        "mcp": {
+          "servers": {
+            "glean": {
+              "args": [
+                "-y",
+                "@gleanwork/mcp-server",
+              ],
+              "command": "npx",
+              "env": {
+                "GLEAN_API_TOKEN": "test-token",
+                "GLEAN_INSTANCE": "example-instance",
+              },
+              "type": "stdio",
+            },
+          },
+        },
+      }
+    `);
+  });
+
+  it('should generate a valid VS Code MCP config template with URL', () => {
+    const config = vscodeClient.configTemplate('https://example.com/rest/api/v1', 'test-token');
+    expect(config).toMatchInlineSnapshot(`
+      {
+        "mcp": {
+          "servers": {
+            "glean": {
+              "args": [
+                "-y",
+                "@gleanwork/mcp-server",
+              ],
+              "command": "npx",
+              "env": {
+                "GLEAN_API_TOKEN": "test-token",
+                "GLEAN_BASE_URL": "https://example.com/rest/api/v1",
+              },
+              "type": "stdio",
+            },
+          },
+        },
+      }
+    `);
+  });
+
+  it('should include success message with instructions', () => {
+    const message = vscodeClient.successMessage('/path/to/config');
+    expect(message).toContain('VS Code MCP configuration has been configured in your user settings');
+    expect(message).toContain('Enable MCP support in VS Code');
+    expect(message).toContain('Restart VS Code');
+    expect(message).toContain('Agent mode');
+    expect(message).toContain('User settings are at:');
+  });
+});


### PR DESCRIPTION
## Description

Implement VS Code client integration for MCP configuration.

I also added `upateConfig` and `hasExistingConfig` methods to the base client interface. This allows us to defer the detection (i.e. if the server is already configured) and the actual updating logic (i.e. writing to the config file) to the underlying `MCPClientConfig` implementation. This is largely because VSCode's structure is pretty different from the others. In order to avoid annoying duplication, I've left the default implementation in the base client (shared by cursor, windsurf, claude), and then override that in the VSCode client.

## Related Issue

Fixes #124 

## Type of Change

<!-- Please check the options that are relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):

## How Has This Been Tested?

<!-- Please describe the tests you've added or the tests that verify this change works correctly -->

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing
- [ ] Other (please describe):

## Checklist

<!-- Please check all that apply -->

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [ ] I have checked for potential breaking changes and addressed them

## Screenshots (if appropriate)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Any other information that is important to this PR -->
