### PR TITLE
chore(testing): drop bigmem

### DIFF
--- a/packages/configure-mcp-server/package.json
+++ b/packages/configure-mcp-server/package.json
@@ -38,7 +38,7 @@
     "lint:ts": "tsc --noEmit",
     "prepare": "pnpm run build",
     "release": "release-it",
-    "test": "NODE_OPTIONS='--max-old-space-size=4096' vitest run",
+    "test": "vitest run",
     "test:all": "pnpm lint && pnpm lint:ts && pnpm test",
     "test:watch": "vitest",
     "watch": "tsc -w"

--- a/packages/local-mcp-server/package.json
+++ b/packages/local-mcp-server/package.json
@@ -38,7 +38,7 @@
     "lint:ts": "tsc --noEmit",
     "prepare": "pnpm run build",
     "release": "release-it",
-    "test": "NODE_OPTIONS='--max-old-space-size=4096' vitest run",
+    "test": "vitest run",
     "test:all": "pnpm lint && pnpm lint:ts && pnpm test",
     "test:watch": "vitest",
     "watch": "tsc -w"

--- a/packages/mcp-server-utils/package.json
+++ b/packages/mcp-server-utils/package.json
@@ -72,7 +72,7 @@
     "lint:ts": "tsc --noEmit",
     "prepare": "pnpm run build",
     "release": "release-it",
-    "test": "NODE_OPTIONS='--max-old-space-size=4096' vitest run",
+    "test": "vitest run",
     "test:all": "pnpm lint && pnpm lint:ts && pnpm test",
     "test:watch": "vitest",
     "watch": "tsc -w"


### PR DESCRIPTION
remove `--max-old-space-size=4096'` from test commands.  Tests still pass, we don't need to aggressively demand lots of memory.


Downstream of #146
