### PR TITLE
dev(lsp): remove ts path aliases

### DIFF
--- a/packages/configure-mcp-server/tsconfig.json
+++ b/packages/configure-mcp-server/tsconfig.json
@@ -17,9 +17,6 @@
     "allowJs": true,
     "skipLibCheck": true,
     "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/lib/*"],
-      "$/*": ["src/*"],
-    }
+    "paths": {}
   }
 }

--- a/packages/local-mcp-server/tsconfig.json
+++ b/packages/local-mcp-server/tsconfig.json
@@ -17,11 +17,6 @@
     "allowJs": true,
     "skipLibCheck": true,
     "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/lib/*"],
-      "$/*": ["src/*"],
-      "$cli/*": ["src/cli/*"],
-      "$test/*": ["src/test/*"]
-    }
+    "paths": {}
   }
 }

--- a/packages/mcp-server-utils/tsconfig.json
+++ b/packages/mcp-server-utils/tsconfig.json
@@ -17,9 +17,6 @@
     "allowJs": true,
     "skipLibCheck": true,
     "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/lib/*"],
-      "$/*": ["src/*"]
-    }
+    "paths": {}
   }
 }


### PR DESCRIPTION
These path aliases hurt rather than help.  They cause auto-completion imports to be wrong and rely on tsc-alias, but we don't use tsc-alias.

We can add the path imports back in if we care, and if we do we should add tsc-alias at the same time.

Downstream of #146
