### PR TITLE
feat: configure remote mcp-server

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -34,6 +34,17 @@
       "args": ["--trace", "auth-test"],
       "smartStep": true,
       "console": "integratedTerminal"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug CLI (setup-mcp-remote)",
+      "autoAttachChildProcesses": true,
+      "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
+      "program": "packages/configure-mcp-server/build/index.js",
+      "args": ["--trace", "setup-mcp-remote"],
+      "smartStep": true,
+      "console": "integratedTerminal"
     }
   ]
 }

--- a/packages/configure-mcp-server/src/common/env.ts
+++ b/packages/configure-mcp-server/src/common/env.ts
@@ -1,0 +1,3 @@
+export function isOAuthEnabled() {
+  return !!process.env.GLEAN_OAUTH_ENABLED;
+}

--- a/packages/configure-mcp-server/src/configure/client/claude.ts
+++ b/packages/configure-mcp-server/src/configure/client/claude.ts
@@ -42,7 +42,7 @@ const claudeClient = createBaseClient(
   [
     'Restart Claude Desktop',
     'You should see a hammer icon in the input box, indicating MCP tools are available',
-    'Click the hammer to see available tools including Glean search and chat',
+    'Click the hammer to see available tools',
   ],
   claudePathResolver,
 );

--- a/packages/configure-mcp-server/src/configure/client/cursor.ts
+++ b/packages/configure-mcp-server/src/configure/client/cursor.ts
@@ -16,7 +16,7 @@ export const cursorConfigPath: MCPConfigPath = {
  */
 const cursorClient = createBaseClient('Cursor', cursorConfigPath, [
   'Restart Cursor',
-  'Agent will now have access to Glean search and chat tools',
+  'Agent will now have access to Glean tools',
   "You'll be asked for approval when Agent uses these tools",
 ]);
 

--- a/packages/configure-mcp-server/src/index.ts
+++ b/packages/configure-mcp-server/src/index.ts
@@ -31,6 +31,7 @@ import {
   discoverOAuthConfig,
   forceAuthorize,
   forceRefreshTokens,
+  setupMcpRemote,
 } from '@gleanwork/mcp-server-utils/auth';
 import { chat, formatResponse } from '@gleanwork/mcp-server-utils/tools/chat';
 import { VERSION } from './common/version.js';
@@ -49,8 +50,7 @@ async function main() {
 
   const clientList = Object.keys(availableClients).join(', ');
 
-  const cli = meow(
-    `
+  const help_default = `
     Usage
       Configure popular MCP clients to add Glean as an MCP server.
 
@@ -61,11 +61,11 @@ async function main() {
       help        Show this help message
 
     Options for configure
-      --client, -c   MCP client to configure for (${clientList || 'loading available clients...'})
-      --token, -t    Glean API token (required)
-      --instance, -i   Glean instance name
-      --env, -e      Path to .env file containing GLEAN_INSTANCE and GLEAN_API_TOKEN
-      --workspace    Create workspace configuration instead of global (VS Code only)
+      --client, -c    MCP client to configure for (${clientList || 'loading available clients...'})
+      --token, -t     Glean API token (required)
+      --instance, -i  Glean instance name
+      --env, -e       Path to .env file containing GLEAN_INSTANCE and GLEAN_API_TOKEN
+      --workspace     Create workspace configuration instead of global (VS Code only)
 
     Examples
       $ npx @gleanwork/configure-mcp-server --client cursor --token glean_api_xyz --instance my-company
@@ -76,43 +76,92 @@ async function main() {
     Run 'npx @gleanwork/configure-mcp-server help' for more details on supported clients
     
     Version: v${VERSION}
-  `,
-    {
-      importMeta: import.meta,
-      flags: {
-        client: {
-          type: 'string',
-          shortFlag: 'c',
-        },
-        token: {
-          type: 'string',
-          shortFlag: 't',
-        },
-        instance: {
-          type: 'string',
-          shortFlag: 'i',
-        },
-        url: {
-          type: 'string',
-          shortFlag: 'u',
-        },
-        env: {
-          type: 'string',
-          shortFlag: 'e',
-        },
-        help: {
-          type: 'boolean',
-          shortFlag: 'h',
-        },
-        trace: {
-          type: 'boolean',
-        },
-        workspace: {
-          type: 'boolean',
-        },
+`;
+
+  const betaEnabled = process.env.GLEAN_BETA_ENABLED;
+  const help_beta = `
+    Usage
+      Configure popular MCP clients to add Glean as an MCP server.
+
+      Available MCP servers:
+
+        local     A local server using Glean's API to access common tools (search, chat)
+        remote    Connect to Glean's hosted MCP servers (default tools and agents).
+        
+
+      $ npx @gleanwork/configure-mcp-server --client <client-name> [options]
+
+    Commands
+      local       Configure Glean's local MCP server for a given client
+      remote      Configure Glean's remote MCP server for a given client
+      help        Show this help message
+
+    Options for local
+      --client, -c    MCP client to configure for (${clientList || 'loading available clients...'})
+      --token, -t     Glean API token (required)
+      --instance, -i  Glean instance name
+      --env, -e       Path to .env file containing GLEAN_INSTANCE and GLEAN_API_TOKEN
+      --workspace     Create workspace configuration instead of global (VS Code only)
+
+    Options for remote
+      --agents        Connect your Glean Agents to your MCP client.  If unset, will connect the default tools.
+      --client, -c    MCP client to configure for (${clientList || 'loading available clients...'})
+      --token, -t     Glean API token (required)
+      --instance, -i  Glean instance name
+      --env, -e       Path to .env file containing GLEAN_INSTANCE and GLEAN_API_TOKEN
+      --workspace     Create workspace configuration instead of global (VS Code only)
+
+    Examples
+      $ npx @gleanwork/configure-mcp-server remote --client cursor --token glean_api_xyz --instance my-company
+      $ npx @gleanwork/configure-mcp-server remote --agents --client claude --token glean_api_xyz --instance my-company
+      $ npx @gleanwork/configure-mcp-server remote --client windsurf --env ~/.glean.env
+      $ npx @gleanwork/configure-mcp-server remote --client vscode --token glean_api_xyz --instance my-company --workspace
+
+    Run 'npx @gleanwork/configure-mcp-server help' for more details on supported clients
+    
+    Version: v${VERSION}
+
+`;
+
+  const cli = meow(betaEnabled ? help_beta : help_default, {
+    importMeta: import.meta,
+    flags: {
+      agents: {
+        type: 'boolean',
+        default: false,
+      },
+      client: {
+        type: 'string',
+        shortFlag: 'c',
+      },
+      token: {
+        type: 'string',
+        shortFlag: 't',
+      },
+      instance: {
+        type: 'string',
+        shortFlag: 'i',
+      },
+      url: {
+        type: 'string',
+        shortFlag: 'u',
+      },
+      env: {
+        type: 'string',
+        shortFlag: 'e',
+      },
+      help: {
+        type: 'boolean',
+        shortFlag: 'h',
+      },
+      trace: {
+        type: 'boolean',
+      },
+      workspace: {
+        type: 'boolean',
       },
     },
-  );
+  });
 
   if (!cli.flags.trace) {
     Logger.getInstance().setLogLevel(LogLevel.INFO);
@@ -121,13 +170,48 @@ async function main() {
   trace(process.title, `ppid/pid: [${process.ppid} / ${process.pid}]`);
   trace(process.execPath, process.execArgv, process.argv);
 
-  // Get the command, defaulting to 'configure' if none provided
-  const command =
-    cli.input.length === 0 ? 'configure' : cli.input[0].toLowerCase();
-
+  // Get the command, defaulting to 'local' if none provided
+  const command = cli.input.length === 0 ? 'local' : cli.input[0].toLowerCase();
   switch (command) {
-    case 'configure': {
-      const { client, token, instance, url, env, workspace } = cli.flags;
+    case 'remote': {
+      if(!betaEnabled) {
+        console.warn(`
+
+@gleanwork/configure-mcp-server remote called without GLEAN_ENABLE_BETA=true
+
+Please note Glean-hosted MCP servers are in private beta.  Make sure your
+instance is opted into the private beta or your assistant won't be able to
+connect after configuration.
+
+`);
+      }
+
+      const { client, token, instance, url, env, workspace, agents } =
+        cli.flags;
+
+      if (!(await validateFlags(client, token, instance, url, env))) {
+        process.exit(1);
+      }
+
+      try {
+        await configure(client as string, {
+          token,
+          instance,
+          url,
+          envPath: env,
+          remote: true,
+          agents,
+          workspace,
+        });
+      } catch (error: any) {
+        console.error(`Configuration failed: ${error.message}`);
+        process.exit(1);
+      }
+      break;
+    }
+    case 'local': {
+      const { client, token, instance, url, env, workspace } =
+        cli.flags;
 
       if (!(await validateFlags(client, token, instance, url, env))) {
         process.exit(1);
@@ -199,6 +283,19 @@ async function main() {
         console.error(
           `Failed to validate access token with server: ${err.message}`,
         );
+        process.exit(1);
+      }
+      break;
+    }
+
+    case 'setup-mcp-remote': {
+      try {
+        trace('setup-mcp-remote(tools)');
+        await setupMcpRemote({ target: 'default' });
+        console.log('mcp-remote set up');
+      } catch (err: any) {
+        error('setup-mcp-remote error', err);
+        console.error(`Failed to set up mcp-remote: ${err.message}`);
         process.exit(1);
       }
       break;

--- a/packages/mcp-server-utils/package.json
+++ b/packages/mcp-server-utils/package.json
@@ -89,6 +89,7 @@
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.23.0",
     "@gleanwork/api-client": "0.6.1",
+    "@gleanwork/connect-mcp-server": "^0.2.0",
     "@release-it-plugins/lerna-changelog": "^7.0.0",
     "@types/node": "^22.14.0",
     "@typescript-eslint/eslint-plugin": "^8.33.1",

--- a/packages/mcp-server-utils/src/auth/error.ts
+++ b/packages/mcp-server-utils/src/auth/error.ts
@@ -41,6 +41,10 @@ export enum AuthErrorCode {
   InvalidConfig = 'ERR_A_19',
   /** Unexpected response fetching access token */
   UnexpectedAuthGrantResponse = 'ERR_A_20',
+  /** Missing OAuth metadata required for MCP remote setup */
+  MissingOAuthMetadata = 'ERR_A_21',
+  /** Missing OAuth tokens required for MCP remote setup */
+  MissingOAuthTokens = 'ERR_A_22',
 }
 
 /**

--- a/packages/mcp-server-utils/src/auth/oauth-cache.ts
+++ b/packages/mcp-server-utils/src/auth/oauth-cache.ts
@@ -84,8 +84,8 @@ function isCacheFresh(timestamp: Date) {
 
 function buildOAuthMetadataCacheFilePath() {
   const stateDir = getStateDir('glean');
-  const tokensFile = path.join(stateDir, 'oauth.json');
-  return tokensFile;
+  const oauthMetadataFile = path.join(stateDir, 'oauth.json');
+  return oauthMetadataFile;
 }
 
 function ensureOAuthMetadataCacheFilePath() {

--- a/packages/mcp-server-utils/src/auth/types.ts
+++ b/packages/mcp-server-utils/src/auth/types.ts
@@ -69,3 +69,19 @@ function hasCommonAuthResponseFields(json: any): boolean {
     'interval' in json
   );
 }
+
+// https://github.com/gleanwork/typescript-sdk/blob/0fcb3efd3405a2d96af549ba5b6490fd9ffbb292/src/shared/auth.ts#L106-L111
+export interface McpRemoteClientInfo {
+  client_id: string;
+  client_secret?: string;
+  redirect_uris: string[];
+}
+
+// https://github.com/gleanwork/typescript-sdk/blob/0fcb3efd3405a2d96af549ba5b6490fd9ffbb292/src/shared/auth.ts#L62-L70
+export interface McpRemoteTokens {
+  access_token: string;
+  token_type: string;
+  expires_in?: number | undefined;
+  scope?: string | undefined;
+  refresh_token?: string | undefined;
+}

--- a/packages/mcp-server-utils/src/util/index.ts
+++ b/packages/mcp-server-utils/src/util/index.ts
@@ -1,2 +1,4 @@
+export type RemoteMcpTargets = 'agents' | 'default';
+
 export * from './object.js';
 export * from './preflight.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,6 +242,9 @@ importers:
       '@gleanwork/api-client':
         specifier: 0.6.1
         version: 0.6.1(zod@3.25.46)
+      '@gleanwork/connect-mcp-server':
+        specifier: ^0.2.0
+        version: 0.2.1
       '@release-it-plugins/lerna-changelog':
         specifier: ^7.0.0
         version: 7.0.0(release-it@17.11.0(typescript@5.8.3))
@@ -518,6 +521,10 @@ packages:
         optional: true
       react-dom:
         optional: true
+
+  '@gleanwork/connect-mcp-server@0.2.1':
+    resolution: {integrity: sha512-PRzf+BVqp7ObN/7523kag3LyEYtn0/juY3NkCuaR0FNYu4NKvQaMgAfj8LTfhVIA2OlGJ64o1U5Em8Uh0UZ4Tw==}
+    hasBin: true
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -995,6 +1002,10 @@ packages:
   '@vitest/utils@3.2.3':
     resolution: {integrity: sha512-4zFBCU5Pf+4Z6v+rwnZ1HU1yzOKKvDkMXZrymE2PBlbjKJRlrOxbvpfPSvJTGRIwGoahaOGvp+kbCoxifhzJ1Q==}
 
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -1065,6 +1076,9 @@ packages:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
     engines: {node: '>= 0.4'}
 
+  array-flatten@1.1.1:
+    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
@@ -1113,6 +1127,10 @@ packages:
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  body-parser@1.20.3:
+    resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   body-parser@2.2.0:
     resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
@@ -1279,6 +1297,10 @@ packages:
   console-test-helpers@0.3.3:
     resolution: {integrity: sha512-HOInu18dnmeZ+sACk2QMHBgN3wa1cZtKPxRcQxxKNgPx91X+z3Z0lVwQAxmTprmLrRPMHT4izvkPYfi+UZoyxQ==}
 
+  content-disposition@0.5.4:
+    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
+    engines: {node: '>= 0.6'}
+
   content-disposition@1.0.0:
     resolution: {integrity: sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==}
     engines: {node: '>= 0.6'}
@@ -1287,9 +1309,16 @@ packages:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
 
+  cookie-signature@1.0.6:
+    resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
+
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
     engines: {node: '>=6.6.0'}
+
+  cookie@0.7.1:
+    resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
+    engines: {node: '>= 0.6'}
 
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
@@ -1331,6 +1360,14 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
 
   debug@4.4.1:
     resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
@@ -1401,6 +1438,10 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
+  destroy@1.2.0:
+    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
@@ -1447,6 +1488,10 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  encodeurl@1.0.2:
+    resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
+    engines: {node: '>= 0.8'}
 
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
@@ -1618,6 +1663,10 @@ packages:
     peerDependencies:
       express: ^4.11 || 5 || ^5.0.0-beta.1
 
+  express@4.21.2:
+    resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
+    engines: {node: '>= 0.10.0'}
+
   express@5.1.0:
     resolution: {integrity: sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==}
     engines: {node: '>= 18'}
@@ -1661,6 +1710,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@1.3.1:
+    resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
+    engines: {node: '>= 0.8'}
+
   finalhandler@2.1.0:
     resolution: {integrity: sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==}
     engines: {node: '>= 0.8'}
@@ -1702,6 +1755,10 @@ packages:
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
 
   fresh@2.0.0:
@@ -2317,6 +2374,10 @@ packages:
   mdast-util-to-string@3.2.0:
     resolution: {integrity: sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==}
 
+  media-typer@0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
@@ -2329,6 +2390,9 @@ packages:
     resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
     engines: {node: '>=18'}
 
+  merge-descriptors@1.0.3:
+    resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
@@ -2339,6 +2403,10 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  methods@1.1.2:
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
 
   micromark-core-commonmark@1.1.0:
     resolution: {integrity: sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==}
@@ -2423,6 +2491,11 @@ packages:
     resolution: {integrity: sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==}
     engines: {node: '>= 0.6'}
 
+  mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
@@ -2498,6 +2571,9 @@ packages:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
 
+  ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -2529,6 +2605,10 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
 
   negotiator@0.6.4:
     resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
@@ -2736,6 +2816,9 @@ packages:
     resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
     engines: {node: 20 || >=22}
 
+  path-to-regexp@0.1.12:
+    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
+
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
@@ -2847,6 +2930,10 @@ packages:
     resolution: {integrity: sha512-FLpr4flz5xZTSJxSeaheeMKN/EDzMdK7b8PTOC6a5PYFKTucWbdqjgqaEyH0shFiSJrVB1+Qqi4Tk19ccU6Aug==}
     engines: {node: '>=12.20'}
 
+  qs@6.13.0:
+    resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
+    engines: {node: '>=0.6'}
+
   qs@6.14.0:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
     engines: {node: '>=0.6'}
@@ -2860,6 +2947,10 @@ packages:
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
+
+  raw-body@2.5.2:
+    resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
+    engines: {node: '>= 0.8'}
 
   raw-body@3.0.0:
     resolution: {integrity: sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==}
@@ -3022,9 +3113,17 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@0.19.0:
+    resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
+    engines: {node: '>= 0.8.0'}
+
   send@1.2.0:
     resolution: {integrity: sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==}
     engines: {node: '>= 18'}
+
+  serve-static@1.16.2:
+    resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
+    engines: {node: '>= 0.8.0'}
 
   serve-static@2.2.0:
     resolution: {integrity: sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==}
@@ -3341,6 +3440,10 @@ packages:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
 
+  type-is@1.6.18:
+    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
@@ -3424,6 +3527,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  utils-merge@1.0.1:
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    engines: {node: '>= 0.4.0'}
 
   uvu@0.5.6:
     resolution: {integrity: sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==}
@@ -3794,6 +3901,13 @@ snapshots:
   '@gleanwork/api-client@0.6.1(zod@3.25.46)':
     dependencies:
       zod: 3.25.46
+
+  '@gleanwork/connect-mcp-server@0.2.1':
+    dependencies:
+      express: 4.21.2
+      open: 10.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   '@humanfs/core@0.19.1': {}
 
@@ -4320,6 +4434,11 @@ snapshots:
       loupe: 3.1.3
       tinyrainbow: 2.0.0
 
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.1
@@ -4386,6 +4505,8 @@ snapshots:
       call-bound: 1.0.4
       is-array-buffer: 3.0.5
 
+  array-flatten@1.1.1: {}
+
   arraybuffer.prototype.slice@1.0.4:
     dependencies:
       array-buffer-byte-length: 1.0.2
@@ -4441,6 +4562,23 @@ snapshots:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  body-parser@1.20.3:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      http-errors: 2.0.0
+      iconv-lite: 0.4.24
+      on-finished: 2.4.1
+      qs: 6.13.0
+      raw-body: 2.5.2
+      type-is: 1.6.18
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   body-parser@2.2.0:
     dependencies:
@@ -4645,13 +4783,21 @@ snapshots:
     dependencies:
       recursive-readdir-sync: 1.0.6
 
+  content-disposition@0.5.4:
+    dependencies:
+      safe-buffer: 5.2.1
+
   content-disposition@1.0.0:
     dependencies:
       safe-buffer: 5.2.1
 
   content-type@1.0.5: {}
 
+  cookie-signature@1.0.6: {}
+
   cookie-signature@1.2.2: {}
+
+  cookie@0.7.1: {}
 
   cookie@0.7.2: {}
 
@@ -4702,6 +4848,10 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  debug@2.6.9:
+    dependencies:
+      ms: 2.0.0
 
   debug@4.4.1:
     dependencies:
@@ -4758,6 +4908,8 @@ snapshots:
 
   dequal@2.0.3: {}
 
+  destroy@1.2.0: {}
+
   detect-indent@6.1.0: {}
 
   detect-indent@7.0.1: {}
@@ -4789,6 +4941,8 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  encodeurl@1.0.2: {}
 
   encodeurl@2.0.0: {}
 
@@ -5051,6 +5205,42 @@ snapshots:
     dependencies:
       express: 5.1.0
 
+  express@4.21.2:
+    dependencies:
+      accepts: 1.3.8
+      array-flatten: 1.1.1
+      body-parser: 1.20.3
+      content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookie: 0.7.1
+      cookie-signature: 1.0.6
+      debug: 2.6.9
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 1.3.1
+      fresh: 0.5.2
+      http-errors: 2.0.0
+      merge-descriptors: 1.0.3
+      methods: 1.1.2
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.12
+      proxy-addr: 2.0.7
+      qs: 6.13.0
+      range-parser: 1.2.1
+      safe-buffer: 5.2.1
+      send: 0.19.0
+      serve-static: 1.16.2
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   express@5.1.0:
     dependencies:
       accepts: 2.0.0
@@ -5121,6 +5311,18 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  finalhandler@1.3.1:
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.1
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   finalhandler@2.1.0:
     dependencies:
       debug: 4.4.1
@@ -5189,6 +5391,8 @@ snapshots:
       mime-types: 2.1.35
 
   forwarded@0.2.0: {}
+
+  fresh@0.5.2: {}
 
   fresh@2.0.0: {}
 
@@ -5826,17 +6030,23 @@ snapshots:
     dependencies:
       '@types/mdast': 3.0.15
 
+  media-typer@0.3.0: {}
+
   media-typer@1.1.0: {}
 
   memorystream@0.3.1: {}
 
   meow@13.2.0: {}
 
+  merge-descriptors@1.0.3: {}
+
   merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  methods@1.1.2: {}
 
   micromark-core-commonmark@1.1.0:
     dependencies:
@@ -5988,6 +6198,8 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
+  mime@1.6.0: {}
+
   mimic-fn@2.1.0: {}
 
   mimic-fn@4.0.0: {}
@@ -6055,6 +6267,8 @@ snapshots:
 
   mri@1.2.0: {}
 
+  ms@2.0.0: {}
+
   ms@2.1.3: {}
 
   msw@2.10.2(@types/node@22.15.29)(typescript@5.8.3):
@@ -6095,6 +6309,8 @@ snapshots:
   nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
+
+  negotiator@0.6.3: {}
 
   negotiator@0.6.4: {}
 
@@ -6334,6 +6550,8 @@ snapshots:
       lru-cache: 11.0.2
       minipass: 7.1.2
 
+  path-to-regexp@0.1.12: {}
+
   path-to-regexp@6.3.0: {}
 
   path-to-regexp@8.2.0: {}
@@ -6419,6 +6637,10 @@ snapshots:
     dependencies:
       escape-goat: 4.0.0
 
+  qs@6.13.0:
+    dependencies:
+      side-channel: 1.1.0
+
   qs@6.14.0:
     dependencies:
       side-channel: 1.1.0
@@ -6428,6 +6650,13 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   range-parser@1.2.1: {}
+
+  raw-body@2.5.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.0
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
 
   raw-body@3.0.0:
     dependencies:
@@ -6648,6 +6877,24 @@ snapshots:
 
   semver@7.7.2: {}
 
+  send@0.19.0:
+    dependencies:
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.0
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   send@1.2.0:
     dependencies:
       debug: 4.4.1
@@ -6661,6 +6908,15 @@ snapshots:
       on-finished: 2.4.1
       range-parser: 1.2.1
       statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@1.16.2:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 0.19.0
     transitivePeerDependencies:
       - supports-color
 
@@ -6993,6 +7249,11 @@ snapshots:
 
   type-fest@4.41.0: {}
 
+  type-is@1.6.18:
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.1.35
+
   type-is@2.0.1:
     dependencies:
       content-type: 1.0.5
@@ -7094,6 +7355,8 @@ snapshots:
       requires-port: 1.0.0
 
   util-deprecate@1.0.2: {}
+
+  utils-merge@1.0.1: {}
 
   uvu@0.5.6:
     dependencies:


### PR DESCRIPTION
Updates configure to have two subcommands

- `npx @gleanwork/configure-mcp-server local`
- `npx @gleanwork/configure-mcp-server remote`

`local` is the default and configures the local mcp server.

`remote` sets up our fork of `mcp-remote` to connect to either the `agents` or `tools` MCP servers.


### Authentication with Remote MCP Servers

If OAuth is enabled via the environment variable `GLEAN_OAUTH_ENABLED`, after authentication the tokens and client information are copied to where `mcp-remote` will look for them.  The access token is given a very short expiration (1s) so that mcp-go will use its own acquired access tokens.  The important part is that it has the refresh token.

**Note**: This is a stop-gap until we can fully support the authorization spec on the server.

#### Refresh Token Expiration

The DX for refresh token expiration is currently quite poor.  The user must re-run the configuration tool again to run through the device flow auth.  This DX will improve when we fully support the authorization spec and can use the flow the SDK expects, using dynamic client registration.

