### PR TITLE
fix: Ensure `build/` is cleared before running `tsc`

### DIFF
--- a/packages/configure-mcp-server/package.json
+++ b/packages/configure-mcp-server/package.json
@@ -33,7 +33,7 @@
     "!build/vitest.config.*"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "rimraf build && tsc",
     "format": "prettier --write \"src/**/*.ts\"",
     "lint": "npm-run-all --sequential lint:*",
     "lint:eslint": "eslint \"src/**/*.ts\" --fix",

--- a/packages/local-mcp-server/package.json
+++ b/packages/local-mcp-server/package.json
@@ -33,7 +33,7 @@
     "!build/vitest.config.*"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "rimraf build && tsc",
     "format": "prettier --write \"src/**/*.ts\"",
     "lint": "npm-run-all --sequential lint:*",
     "lint:eslint": "eslint \"src/**/*.ts\" --fix",

--- a/packages/mcp-server-utils/package.json
+++ b/packages/mcp-server-utils/package.json
@@ -64,7 +64,7 @@
     "!build/vitest.config.*"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "rimraf build && tsc",
     "format": "prettier --write \"src/**/*.ts\"",
     "lint": "npm-run-all --sequential lint:*",
     "lint:eslint": "eslint \"src/**/*.ts\" --fix",


### PR DESCRIPTION
Without this change, `tsc` will happily build into `build/` again *but* it never clears deleted files. This means if you move a file, you are mega trolled.

Stacked on top of #154 