### PR TITLE
[tool] Add read_documents MCP tool for retrieving documents by ID or URL

### DIFF
--- a/packages/local-mcp-server/README.md
+++ b/packages/local-mcp-server/README.md
@@ -12,6 +12,7 @@ The Glean MCP Server is a [Model Context Protocol (MCP)](https://modelcontextpro
 - **Company Search**: Access Glean's powerful content search capabilities
 - **People Profile Search**: Access Glean's people directory
 - **Chat**: Interact with Glean's AI assistant
+- **Read Documents**: Retrieve documents from Glean by ID or URL
 - **MCP Compliant**: Implements the Model Context Protocol specification
 
 ## Tools
@@ -28,6 +29,9 @@ The Glean MCP Server is a [Model Context Protocol (MCP)](https://modelcontextpro
 
   Search Glean's People directory to find employee information.
 
+- ### read_documents
+
+  Read documents from Glean by providing document IDs or URLs. This tool allows you to retrieve the full content of specific documents for detailed analysis or reference.
 
 ## MCP Client Configuration
 

--- a/packages/local-mcp-server/src/server.ts
+++ b/packages/local-mcp-server/src/server.ts
@@ -27,7 +27,7 @@ import {
   formatGleanError,
   isGleanError,
 } from '@gleanwork/mcp-server-utils/errors';
-import { VERSION } from './common/version';
+import { VERSION } from './common/version.js';
 
 export const TOOL_NAMES = {
   companySearch: 'company_search',

--- a/packages/local-mcp-server/src/server.ts
+++ b/packages/local-mcp-server/src/server.ts
@@ -21,6 +21,7 @@ import { zodToJsonSchema } from 'zod-to-json-schema';
 import * as search from './tools/search.js';
 import * as chat from './tools/chat.js';
 import * as peopleProfileSearch from './tools/people_profile_search.js';
+import * as readDocuments from './tools/read_documents.js';
 import {} from '@gleanwork/mcp-server-utils/auth';
 import {
   formatGleanError,
@@ -32,6 +33,7 @@ export const TOOL_NAMES = {
   companySearch: 'company_search',
   peopleProfileSearch: 'people_profile_search',
   chat: 'chat',
+  readDocuments: 'read_documents',
 };
 
 /**
@@ -101,6 +103,23 @@ export async function listToolsHandler() {
           peopleProfileSearch.ToolPeopleProfileSearchSchema,
         ),
       },
+      {
+        name: TOOL_NAMES.readDocuments,
+        description: `Read documents from Glean by ID or URL
+
+        Example request:
+
+        "documentSpecs": [
+            {
+                "id": "doc-123",
+            },
+            {
+                "url": "https://example.com/doc2"
+            }
+          ]
+        `,
+        inputSchema: zodToJsonSchema(readDocuments.ToolReadDocumentsSchema),
+      },
     ],
   };
 }
@@ -145,6 +164,19 @@ export async function callToolHandler(
         );
         const result = await peopleProfileSearch.peopleProfileSearch(args);
         const formattedResults = peopleProfileSearch.formatResponse(result);
+
+        return {
+          content: [{ type: 'text', text: formattedResults }],
+          isError: false,
+        };
+      }
+
+      case TOOL_NAMES.readDocuments: {
+        const args = readDocuments.ToolReadDocumentsSchema.parse(
+          request.params.arguments,
+        );
+        const result = await readDocuments.readDocuments(args);
+        const formattedResults = readDocuments.formatResponse(result);
 
         return {
           content: [{ type: 'text', text: formattedResults }],

--- a/packages/local-mcp-server/src/test/tools/read_documents.test.ts
+++ b/packages/local-mcp-server/src/test/tools/read_documents.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { readDocuments, formatResponse, ToolReadDocumentsSchema } from '../../tools/read_documents'
+import { readDocuments, formatResponse, ToolReadDocumentsSchema } from '../../tools/read_documents.js'
 
 const mockFetch = vi.fn();
 global.fetch = mockFetch;

--- a/packages/local-mcp-server/src/test/tools/read_documents.test.ts
+++ b/packages/local-mcp-server/src/test/tools/read_documents.test.ts
@@ -301,15 +301,18 @@ describe('read-documents tool', () => {
       };
 
       const result = formatResponse(response);
+      
+      // Normalize date formatting to avoid timezone differences between environments
+      const normalizedResult = result.replace(/Created: \d{1,2}\/\d{1,2}\/\d{4}/, 'Created: [NORMALIZED_DATE]');
 
-      expect(result).toMatchInlineSnapshot(`
+      expect(normalizedResult).toMatchInlineSnapshot(`
         "Retrieved 1 document:
 
         [1] Test Document
                 Type: Article
                 Source: confluence
                 Author: John Doe
-        Created: 12/31/2022
+        Created: [NORMALIZED_DATE]
         URL: https://example.com/doc1
 
                 Content:

--- a/packages/local-mcp-server/src/test/tools/read_documents.test.ts
+++ b/packages/local-mcp-server/src/test/tools/read_documents.test.ts
@@ -1,0 +1,219 @@
+/**
+ * @fileoverview Tests for the read documents tool implementation.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readDocuments, formatResponse, ToolReadDocumentsSchema } from '../../tools/read_documents'
+import { getClient } from '../../common/client.js';
+
+vi.mock('../../common/client.js');
+
+describe('read-documents tool', () => {
+  const mockClient = {
+    documents: {
+      retrieve: vi.fn(),
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getClient).mockResolvedValue(mockClient as any);
+  });
+
+  describe('ToolReadDocumentsSchema', () => {
+    it('should validate request with document IDs', () => {
+      const validRequest = {
+        documentSpecs: [
+          { id: 'doc-123' },
+          { id: 'doc-456' },
+        ],
+      };
+
+      const result = ToolReadDocumentsSchema.safeParse(validRequest);
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate request with URLs', () => {
+      const validRequest = {
+        documentSpecs: [
+          { url: 'https://example.com/doc1' },
+          { url: 'https://example.com/doc2' },
+        ],
+      };
+
+      const result = ToolReadDocumentsSchema.safeParse(validRequest);
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate request with mixed IDs and URLs', () => {
+      const validRequest = {
+        documentSpecs: [
+          { id: 'doc-123' },
+          { url: 'https://example.com/doc1' },
+        ],
+      };
+
+      const result = ToolReadDocumentsSchema.safeParse(validRequest);
+      expect(result.success).toBe(true);
+    });
+
+    it('should fail validation without documentSpecs', () => {
+      const invalidRequest = {};
+
+      const result = ToolReadDocumentsSchema.safeParse(invalidRequest);
+      expect(result.success).toBe(false);
+    });
+
+    it('should fail validation with empty documentSpecs array', () => {
+      const invalidRequest = {
+        documentSpecs: [],
+      };
+
+      const result = ToolReadDocumentsSchema.safeParse(invalidRequest);
+      expect(result.success).toBe(false);
+    });
+
+    it('should fail validation with documentSpec missing both id and url', () => {
+      const invalidRequest = {
+        documentSpecs: [{}],
+      };
+
+      const result = ToolReadDocumentsSchema.safeParse(invalidRequest);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('readDocuments', () => {
+    it('should call client.documents.retrieve with document ID', async () => {
+      const mockResponse = {
+        documents: {
+          'doc-123': {
+            id: 'doc-123',
+            title: 'Test Document',
+            content: 'Test content',
+          },
+        },
+      };
+
+      mockClient.documents.retrieve.mockResolvedValue(mockResponse);
+
+      const request = { documentSpecs: [{ id: 'doc-123' }] };
+      const result = await readDocuments(request);
+
+      expect(mockClient.documents.retrieve).toHaveBeenCalledWith({
+        documentSpecs: [{ id: 'doc-123' }],
+      });
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should call client.documents.retrieve with document URL', async () => {
+      const mockResponse = {
+        documents: {
+          'url-1': {
+            title: 'Test Document',
+            url: 'https://example.com/doc1',
+            content: 'Test content',
+          },
+        },
+      };
+
+      mockClient.documents.retrieve.mockResolvedValue(mockResponse);
+
+      const request = { documentSpecs: [{ url: 'https://example.com/doc1' }] };
+      const result = await readDocuments(request);
+
+      expect(mockClient.documents.retrieve).toHaveBeenCalledWith({
+        documentSpecs: [{ url: 'https://example.com/doc1' }],
+      });
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('formatResponse', () => {
+    it('should format single document response correctly', () => {
+      const response = {
+        documents: {
+          'doc-123': {
+            title: 'Test Document',
+            url: 'https://example.com/doc1',
+            docType: 'Article',
+            datasource: 'confluence',
+            body: {
+              textContent: 'This is test content for the document.',
+            },
+            author: 'John Doe',
+            createdAt: '2023-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      const result = formatResponse(response);
+
+      expect(result).toContain('Retrieved 1 document:');
+      expect(result).toContain('[1] Test Document');
+      expect(result).toContain('Type: Article');
+      expect(result).toContain('Source: confluence');
+      expect(result).toContain('Author: John Doe');
+      expect(result).toContain('URL: https://example.com/doc1');
+      expect(result).toContain('This is test content for the document.');
+    });
+
+    it('should format multiple documents response correctly', () => {
+      const response = {
+        documents: {
+          'doc-123': {
+            title: 'First Document',
+            content: 'First content',
+          },
+          'doc-456': {
+            title: 'Second Document',
+            content: 'Second content',
+          },
+        },
+      };
+
+      const result = formatResponse(response);
+
+      expect(result).toContain('Retrieved 2 documents:');
+      expect(result).toContain('[1] First Document');
+      expect(result).toContain('[2] Second Document');
+      expect(result).toContain('First content');
+      expect(result).toContain('Second content');
+    });
+
+    it('should handle empty response', () => {
+      const response = {
+        documents: {},
+      };
+
+      const result = formatResponse(response);
+      expect(result).toBe('No documents found.');
+    });
+
+    it('should handle missing documents field', () => {
+      const response = {};
+
+      const result = formatResponse(response);
+      expect(result).toBe('No documents found.');
+    });
+
+    it('should truncate long content', () => {
+      const longContent = 'A'.repeat(3000);
+      const response = {
+        documents: {
+          'doc-123': {
+            title: 'Long Document',
+            body: {
+              textContent: longContent,
+            },
+          },
+        },
+      };
+
+      const result = formatResponse(response);
+
+      expect(result).toContain('A'.repeat(2000) + '...');
+      expect(result).not.toContain('A'.repeat(2001));
+    });
+  });
+}); 

--- a/packages/local-mcp-server/src/tools/read_documents.ts
+++ b/packages/local-mcp-server/src/tools/read_documents.ts
@@ -1,0 +1,130 @@
+/**
+ * @fileoverview Read documents tool implementation for the Glean MCP server.
+ *
+ * This module provides an interface to read documents from Glean through the MCP protocol.
+ * It defines the schema for read documents parameters and implements the functionality using
+ * the Glean client SDK.
+ *
+ * @module tools/read-documents
+ */
+
+import { z } from 'zod';
+import { getClient } from '../common/client.js';
+import { GetDocumentsRequest, GetDocumentsRequestIncludeField } from '@gleanwork/api-client/models/components';
+
+/**
+ * Schema for Glean read documents requests designed for LLM interaction
+ */
+export const ToolReadDocumentsSchema = z.object({
+  documentSpecs: z
+    .array(
+      z.object({
+        id: z.string().describe('Glean Document ID').optional(),
+        url: z.string().describe('Document URL').optional(),
+      }).refine(
+        (data) => data.id || data.url,
+        {
+          message: "Either id or url must be provided for each document spec",
+          path: ["id", "url"],
+        }
+      )
+    )
+    .describe('List of document specifications to retrieve')
+    .min(1, "At least one document spec must be provided"),
+});
+
+export type ToolReadDocumentsRequest = z.infer<typeof ToolReadDocumentsSchema>;
+
+/**
+ * Maps a simplified read documents request to the format expected by the Glean API.
+ *
+ * @param input Simplified read documents request parameters
+ * @returns Glean API compatible read documents request
+ */
+function convertToAPIReadDocumentsRequest(input: ToolReadDocumentsRequest): GetDocumentsRequest {
+  return {
+    documentSpecs: input.documentSpecs,
+    includeFields: [GetDocumentsRequestIncludeField.DocumentContent],
+  };
+}
+
+/**
+ * Reads documents from Glean.
+ *
+ * @param params The read documents parameters using the simplified schema
+ * @returns The documents
+ * @throws If the read documents request fails
+ */
+export async function readDocuments(params: ToolReadDocumentsRequest) {
+  const mappedParams = convertToAPIReadDocumentsRequest(params);
+  const client = await getClient();
+
+  return await client.documents.retrieve(mappedParams);
+}
+
+/**
+ * Formats read documents results into a human-readable text format.
+ *
+ * @param documentsResponse The raw documents response from Glean API
+ * @returns Formatted documents as text
+ */
+export function formatResponse(documentsResponse: any): string {
+  if (
+    !documentsResponse ||
+    !documentsResponse.documents ||
+    typeof documentsResponse.documents !== 'object'
+  ) {
+    return 'No documents found.';
+  }
+
+  const documents = Object.values(documentsResponse.documents) as any[];
+  
+  if (documents.length === 0) {
+    return 'No documents found.';
+  }
+
+  const formattedDocuments = documents
+    .map((doc: any, index: number) => {
+      const title = doc.title || 'No title';
+      const url = doc.url || '';
+      const docType = doc.docType || 'Document';
+      const datasource = doc.datasource || 'Unknown source';
+      
+      let content = '';
+      if (doc.content && doc.content.fullTextList && Array.isArray(doc.content.fullTextList)) {
+        content = doc.content.fullTextList.join('\n');
+      } else if (doc.content && typeof doc.content === 'string') {
+        content = doc.content;
+      } else {
+        content = 'No content available';
+      }
+
+      if (content.length > 2000) {
+        content = content.substring(0, 2000) + '...';
+      }
+
+      let metadata = '';
+      if (doc.metadata?.author?.name) {
+        metadata += `Author: ${doc.metadata.author.name}\n`;
+      }
+      if (doc.metadata?.createTime) {
+        metadata += `Created: ${new Date(doc.metadata.createTime).toLocaleDateString()}\n`;
+      }
+      if (doc.metadata?.updateTime) {
+        metadata += `Updated: ${new Date(doc.metadata.updateTime).toLocaleDateString()}\n`;
+      }
+
+      return `[${index + 1}] ${title}
+        Type: ${docType}
+        Source: ${datasource}
+        ${metadata}URL: ${url}
+
+        Content:
+        ${content}`;
+    })
+    .join('\n\n---\n\n');
+
+  const totalDocuments = documents.length;
+
+  return `Retrieved ${totalDocuments} document${totalDocuments === 1 ? '' : 's'}:\n\n${formattedDocuments}`;
+} 

--- a/packages/local-mcp-server/src/tools/read_documents.ts
+++ b/packages/local-mcp-server/src/tools/read_documents.ts
@@ -56,10 +56,26 @@ function convertToAPIReadDocumentsRequest(input: ToolReadDocumentsRequest): GetD
  * @throws If the read documents request fails
  */
 export async function readDocuments(params: ToolReadDocumentsRequest) {
-  const mappedParams = convertToAPIReadDocumentsRequest(params);
-  const client = await getClient();
 
-  return await client.documents.retrieve(mappedParams);
+  const mappedParams = convertToAPIReadDocumentsRequest(params);
+
+  // There's a bug in the client SDK, so using fetch directly for now
+  // const client = await getClient();
+  // return await client.documents.retrieve(mappedParams);
+
+  console.error('client response', await client.documents.retrieve(mappedParams))
+
+  // DO NOT MERGE. This is a temporary fix to get the read documents tool working.
+  const response = await fetch(`https://${process.env.GLEAN_INSTANCE}-be.glean.com/rest/api/v1/getdocuments`, {
+    method: 'POST',
+    body: JSON.stringify(mappedParams),
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${process.env.GLEAN_API_TOKEN}`,
+    },
+  });
+
+  return response.json();
 }
 
 /**
@@ -97,10 +113,6 @@ export function formatResponse(documentsResponse: any): string {
         content = doc.content;
       } else {
         content = 'No content available';
-      }
-
-      if (content.length > 2000) {
-        content = content.substring(0, 2000) + '...';
       }
 
       let metadata = '';

--- a/packages/local-mcp-server/src/tools/read_documents.ts
+++ b/packages/local-mcp-server/src/tools/read_documents.ts
@@ -63,8 +63,6 @@ export async function readDocuments(params: ToolReadDocumentsRequest) {
   // const client = await getClient();
   // return await client.documents.retrieve(mappedParams);
 
-  console.error('client response', await client.documents.retrieve(mappedParams))
-
   // DO NOT MERGE. This is a temporary fix to get the read documents tool working.
   const response = await fetch(`https://${process.env.GLEAN_INSTANCE}-be.glean.com/rest/api/v1/getdocuments`, {
     method: 'POST',

--- a/packages/local-mcp-server/src/tools/read_documents.ts
+++ b/packages/local-mcp-server/src/tools/read_documents.ts
@@ -8,10 +8,10 @@
  * @module tools/read-documents
  */
 
-import { z } from 'zod';
-import { getClient } from '../common/client.js';
 import { GetDocumentsRequest, GetDocumentsRequestIncludeField } from '@gleanwork/api-client/models/components';
-import { getConfig, isGleanTokenConfig } from '@gleanwork/mcp-server-utils/config';
+import { AuthError, AuthErrorCode, ensureAuthTokenPresence, loadTokens } from '@gleanwork/mcp-server-utils/auth';
+import { getConfig, isGleanTokenConfig, isOAuthConfig } from '@gleanwork/mcp-server-utils/config';
+import { z } from 'zod';
 
 /**
  * Schema for Glean read documents requests designed for LLM interaction
@@ -63,19 +63,57 @@ export async function readDocuments(params: ToolReadDocumentsRequest) {
   // There's a bug in the client SDK, so using fetch directly for now
   // See https://github.com/gleanwork/api-client-typescript/issues/45
 
-  const config = await getConfig()
+  const config = await getConfig({ discoverOAuth: true });
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
   }
-  if (isGleanTokenConfig(config)) {
+  if (isOAuthConfig(config)) {
+    if (!(await ensureAuthTokenPresence())) {
+      throw new AuthError(
+        'No OAuth tokens found. Please run `npx @gleanwork/configure-mcp-server auth` to authenticate.',
+        { code: AuthErrorCode.InvalidConfig },
+      );
+    }
+
+    const tokens = loadTokens();
+    if (tokens === null) {
+      throw new AuthError(
+        'No OAuth tokens found. Please run `npx @gleanwork/configure-mcp-server auth` to authenticate.',
+        { code: AuthErrorCode.InvalidConfig },
+      );
+    }
+    headers['X-Glean-Auth-Type'] = 'OAUTH';
+    headers['Authorization'] = `Bearer ${tokens?.accessToken}`;
+  } else if (isGleanTokenConfig(config)) {
     headers['Authorization'] = `Bearer ${config.token}`;
+    
+    const { actAs } = config;
+    if (actAs) {
+      headers['X-Glean-Act-As'] = actAs;
+    }
+  } else {
+    throw new AuthError(
+      'Missing or invalid Glean configuration. Please check that your environment variables are set correctly (e.g. GLEAN_INSTANCE or GLEAN_SUBDOMAIN).',
+      { code: AuthErrorCode.InvalidConfig },
+    );
   }
 
-  const response = await fetch(`${config.baseUrl}/rest/api/v1/getdocuments`, {
+  const response = await fetch(`${config.baseUrl}rest/api/v1/getdocuments`, {
     method: 'POST',
     body: JSON.stringify(mappedParams),
     headers,
   });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`API request failed with status ${response.status}: ${errorText}`);
+  }
+
+  const contentType = response.headers.get('content-type');
+  if (!contentType || !contentType.includes('application/json')) {
+    const responseText = await response.text();
+    throw new Error(`Expected JSON response but got ${contentType}: ${responseText}`);
+  }
 
   return response.json();
 }

--- a/packages/mcp-server-utils/package.json
+++ b/packages/mcp-server-utils/package.json
@@ -46,6 +46,11 @@
       "import": "./build/tools/search.js",
       "default": "./build/tools/search.js"
     },
+    "./tools/read-documents": {
+      "types": "./build/tools/read-documents.d.ts",
+      "import": "./build/tools/read-documents.js",
+      "default": "./build/tools/read-documents.js"
+    },
     "./util": {
       "types": "./build/util/index.d.ts",
       "import": "./build/util/index.js",

--- a/packages/mcp-server-utils/package.json
+++ b/packages/mcp-server-utils/package.json
@@ -47,9 +47,9 @@
       "default": "./build/tools/search.js"
     },
     "./tools/read-documents": {
-      "types": "./build/tools/read-documents.d.ts",
-      "import": "./build/tools/read-documents.js",
-      "default": "./build/tools/read-documents.js"
+      "types": "./build/tools/read_documents.d.ts",
+      "import": "./build/tools/read_documents.js",
+      "default": "./build/tools/read_documents.js"
     },
     "./util": {
       "types": "./build/util/index.d.ts",

--- a/packages/mcp-server-utils/package.json
+++ b/packages/mcp-server-utils/package.json
@@ -46,11 +46,6 @@
       "import": "./build/tools/search.js",
       "default": "./build/tools/search.js"
     },
-    "./tools/read-documents": {
-      "types": "./build/tools/read_documents.d.ts",
-      "import": "./build/tools/read_documents.js",
-      "default": "./build/tools/read_documents.js"
-    },
     "./util": {
       "types": "./build/util/index.d.ts",
       "import": "./build/util/index.js",


### PR DESCRIPTION
## Description
Adds a `read_documents` tool to the local MCP server so that we can get full document contents 

## Motivation and Context
There are plenty of examples where having the full document contents really helps, but here's a simple example:
When I drop a link and ask Glean MCP to analyze, it'll either do a search or a chat. Search is somewhat useful, but we're still snippeting there so we don't get the full picture of the document. We should be able to analyze the entirety of the document using the link.


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):

## How Has This Been Tested?

- [X] Unit tests
- [ ] Integration tests
- [X] Manual testing
- [ ] Other (please describe):

## Checklist
- [X] My code follows the code style of this project
- [X] I have updated the documentation accordingly
- [X] I have added tests to cover my changes
- [X] I have checked for potential breaking changes and addressed them

## Screenshots (if appropriate)
Connecting local MCP through local server:
<img width="557" alt="Screenshot 2025-06-16 at 12 23 56 PM" src="https://github.com/user-attachments/assets/441c5366-dbdf-4251-a50f-e4a3d69ad57f" />

## Additional Notes
Seems to be an issue with the response from the client SDK, so filed an issue [here](https://github.com/gleanwork/api-client-typescript/issues/45) and replaced it with a fetch for now
