### PR TITLE
fix(auth): keep unexpired refresh tokens

### DIFF
--- a/packages/mcp-server-utils/src/auth/token-store.ts
+++ b/packages/mcp-server-utils/src/auth/token-store.ts
@@ -86,6 +86,10 @@ export function loadTokens(): Tokens | null {
 }
 
 export function saveTokens(tokens: Tokens) {
+  const existingTokens = loadTokens();
+  if(tokens.refreshToken === undefined) {
+    tokens.refreshToken = existingTokens?.refreshToken;
+  }
   saveTokensToXDGState(tokens);
 }
 


### PR DESCRIPTION
When a refresh response includes a refresh token, save that to tokens.json.  When a refresh response does not include a refresh token (as with gsuite), assume the existing refresh token is unexpired and keep it around.

Also clean up some unnecessary test mocking.
