### PR TITLE
chore(release-it): Correctly disable `npm` integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,7 @@
     ]
   },
   "release-it": {
-    "npm": {
-      "publish": false
-    },
+    "npm": false,
     "git": {
       "tagName": "v${version}",
       "requireCleanWorkingDir": false


### PR DESCRIPTION
`release-it` does a number of things WRT `npm`, the prior config only disabled `npm publish` step itself but left the other things in place (so it was trying to `npm version 9.9.9`, and was errorign since that was already the current version).

This configuration disables *all* of the `npm` functionality for the root, which is what we want -- we want to allow
`@release-it-plugins/workspace` to do all of the npm related stuff.