### PR TITLE
fix(release): Ensure `pnpm-lock.yaml` is updated on release

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.29.0",
-    "@release-it-plugins/workspaces": "^4.2.0",
+    "@release-it-plugins/workspaces": "^4.2.1",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^8.34.1",
     "eslint": "^8.56.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^9.29.0
         version: 9.29.0
       '@release-it-plugins/workspaces':
-        specifier: ^4.2.0
-        version: 4.2.0(release-it@17.11.0(typescript@5.8.3))
+        specifier: ^4.2.1
+        version: 4.2.1(release-it@17.11.0(typescript@5.8.3))
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.0.0
         version: 7.18.0(@typescript-eslint/parser@8.34.1(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
@@ -819,8 +819,8 @@ packages:
     peerDependencies:
       release-it: ^14.0.0 || ^15.1.3 || ^16.0.0 || ^17.0.0
 
-  '@release-it-plugins/workspaces@4.2.0':
-    resolution: {integrity: sha512-hzQMdYWFnLBS/7dfasIWyeD2LUKeL7LT8ldxZgpzon90lW1cEU4Kpad78KmpZl1L188YHAbwVnboE+6i14jlEQ==}
+  '@release-it-plugins/workspaces@4.2.1':
+    resolution: {integrity: sha512-lZEARr5tqsFskTPHBLjmYxqfC/DJkWRc0Q/wjOODHW8rtYPhL1w2zv7fwvgSjhFmMp0OdsJOXzkcSkUDvc9NnA==}
     engines: {node: '>= 16'}
     peerDependencies:
       release-it: ^14.0.0 || ^15.2.0 || ^16.0.0 || ^17.0.0
@@ -4419,7 +4419,7 @@ snapshots:
       - bluebird
       - supports-color
 
-  '@release-it-plugins/workspaces@4.2.0(release-it@17.11.0(typescript@5.8.3))':
+  '@release-it-plugins/workspaces@4.2.1(release-it@17.11.0(typescript@5.8.3))':
     dependencies:
       detect-indent: 6.1.0
       detect-newline: 3.1.0


### PR DESCRIPTION
Updates to land the fix for ensuring that pnpm lockfile is updated before publishing (https://github.com/release-it-plugins/workspaces/pull/120).
