### PR TITLE
fix: vscode configuration of remote MCP Servers

### DIFF
--- a/packages/configure-mcp-server/src/test/cli.test.ts
+++ b/packages/configure-mcp-server/src/test/cli.test.ts
@@ -395,6 +395,7 @@ describe('CLI', () => {
                 "GLEAN_API_TOKEN": "test-token",
                 "GLEAN_INSTANCE": "test-instance",
               },
+              "type": "stdio",
             },
           },
         }
@@ -446,6 +447,7 @@ describe('CLI', () => {
                 "GLEAN_API_TOKEN": "env-token",
                 "GLEAN_INSTANCE": "env-instance",
               },
+              "type": "stdio",
             },
           },
         }
@@ -477,6 +479,7 @@ describe('CLI', () => {
                 "GLEAN_API_TOKEN": "process-env-token",
                 "GLEAN_INSTANCE": "process-env-instance",
               },
+              "type": "stdio",
             },
           },
         }
@@ -520,6 +523,7 @@ describe('CLI', () => {
                 "GLEAN_API_TOKEN": "flag-token",
                 "GLEAN_INSTANCE": "flag-instance",
               },
+              "type": "stdio",
             },
           },
         }
@@ -602,6 +606,7 @@ Error configuring client: API token is required. Please provide a token with the
           "{
             "mcpServers": {
               "glean_local": {
+                "type": "stdio",
                 "command": "npx",
                 "args": [
                   "-y",
@@ -624,6 +629,12 @@ Error configuring client: API token is required. Please provide a token with the
               enabled: true,
             },
           },
+          mcpServers: {
+            "github-remote": {
+              url: "https://api.githubcopilot.com/mcp",
+              authorization_token: "Bearer $MY_TOKEN"
+            }
+          }
         };
 
         createConfigFile(configFilePath, existingConfig);
@@ -672,7 +683,12 @@ Error configuring client: API token is required. Please provide a token with the
               }
             },
             "mcpServers": {
+              "github-remote": {
+                "url": "https://api.githubcopilot.com/mcp",
+                "authorization_token": "Bearer $MY_TOKEN"
+              },
               "glean_local": {
+                "type": "stdio",
                 "command": "npx",
                 "args": [
                   "-y",
@@ -741,6 +757,7 @@ Error configuring client: API token is required. Please provide a token with the
           "{
             "mcpServers": {
               "glean_local": {
+                "type": "stdio",
                 "command": "npx",
                 "args": [
                   "-y",
@@ -757,7 +774,19 @@ Error configuring client: API token is required. Please provide a token with the
       });
 
       it("adds config to existing file that doesn't have Glean config", async () => {
-        const existingConfig = {};
+        const existingConfig = {
+          'some-other-config': {
+            options: {
+              enabled: true,
+            },
+          },
+          mcpServers: {
+            "github-remote": {
+              url: "https://api.githubcopilot.com/mcp",
+              authorization_token: "Bearer $MY_TOKEN"
+            }
+          }
+        };
 
         createConfigFile(configFilePath, existingConfig);
 
@@ -799,8 +828,18 @@ Error configuring client: API token is required. Please provide a token with the
         expect(fs.existsSync(configFilePath)).toBe(true);
         expect(configFileContents).toMatchInlineSnapshot(`
           "{
+            "some-other-config": {
+              "options": {
+                "enabled": true
+              }
+            },
             "mcpServers": {
+              "github-remote": {
+                "url": "https://api.githubcopilot.com/mcp",
+                "authorization_token": "Bearer $MY_TOKEN"
+              },
               "glean_local": {
+                "type": "stdio",
                 "command": "npx",
                 "args": [
                   "-y",
@@ -870,6 +909,7 @@ Error configuring client: API token is required. Please provide a token with the
           "{
             "mcpServers": {
               "glean_local": {
+                "type": "stdio",
                 "command": "npx",
                 "args": [
                   "-y",
@@ -892,6 +932,12 @@ Error configuring client: API token is required. Please provide a token with the
               enabled: true,
             },
           },
+          mcpServers: {
+            "github-remote": {
+              url: "https://api.githubcopilot.com/mcp",
+              authorization_token: "Bearer $MY_TOKEN"
+            }
+          }
         };
 
         createConfigFile(configFilePath, existingConfig);
@@ -941,7 +987,12 @@ Error configuring client: API token is required. Please provide a token with the
               }
             },
             "mcpServers": {
+              "github-remote": {
+                "url": "https://api.githubcopilot.com/mcp",
+                "authorization_token": "Bearer $MY_TOKEN"
+              },
               "glean_local": {
+                "type": "stdio",
                 "command": "npx",
                 "args": [
                   "-y",
@@ -1026,31 +1077,38 @@ Error configuring client: API token is required. Please provide a token with the
         // Normalize JSON to avoid platform-specific escaping issues
         const parsedContents = JSON.parse(configFileContents);
         expect(parsedContents).toMatchInlineSnapshot(`
-        {
-          "mcp": {
-            "servers": {
-              "glean": {
-                "args": [
-                  "-y",
-                  "@gleanwork/local-mcp-server",
-                ],
-                "command": "npx",
-                "env": {
-                  "GLEAN_API_TOKEN": "glean_api_test",
-                  "GLEAN_INSTANCE": "test-domain",
+          {
+            "mcp": {
+              "servers": {
+                "glean_local": {
+                  "args": [
+                    "-y",
+                    "@gleanwork/local-mcp-server",
+                  ],
+                  "command": "npx",
+                  "env": {
+                    "GLEAN_API_TOKEN": "glean_api_test",
+                    "GLEAN_INSTANCE": "test-domain",
+                  },
+                  "type": "stdio",
                 },
-                "type": "stdio",
               },
             },
-          },
-        }
-      `);
+          }
+        `);
       });
 
       it("adds config to existing file that doesn't have Glean config", async () => {
         const existingConfig = {
           'editor.fontSize': 14,
           'workbench.colorTheme': 'Default Dark+',
+          mcp: {
+            servers: {
+            "github-remote": {
+              url: "https://api.githubcopilot.com/mcp",
+              authorization_token: "Bearer $MY_TOKEN"
+            }}
+          }
         };
 
         createConfigFile(configFilePath, existingConfig);
@@ -1085,27 +1143,31 @@ Error configuring client: API token is required. Please provide a token with the
         const parsedConfig = JSON.parse(configFileContents);
 
         expect(parsedConfig).toMatchInlineSnapshot(`
-        {
-          "editor.fontSize": 14,
-          "mcp": {
-            "servers": {
-              "glean": {
-                "args": [
-                  "-y",
-                  "@gleanwork/local-mcp-server",
-                ],
-                "command": "npx",
-                "env": {
-                  "GLEAN_API_TOKEN": "glean_api_test",
-                  "GLEAN_INSTANCE": "test-domain",
+          {
+            "editor.fontSize": 14,
+            "mcp": {
+              "servers": {
+                "github-remote": {
+                  "authorization_token": "Bearer $MY_TOKEN",
+                  "url": "https://api.githubcopilot.com/mcp",
                 },
-                "type": "stdio",
+                "glean_local": {
+                  "args": [
+                    "-y",
+                    "@gleanwork/local-mcp-server",
+                  ],
+                  "command": "npx",
+                  "env": {
+                    "GLEAN_API_TOKEN": "glean_api_test",
+                    "GLEAN_INSTANCE": "test-domain",
+                  },
+                  "type": "stdio",
+                },
               },
             },
-          },
-          "workbench.colorTheme": "Default Dark+",
-        }
-      `);
+            "workbench.colorTheme": "Default Dark+",
+          }
+        `);
       });
     });
   });
@@ -1166,23 +1228,24 @@ Error configuring client: API token is required. Please provide a token with the
 
       expect(fs.existsSync(configFilePath)).toBe(true);
       expect(configFileContents).toMatchInlineSnapshot(`
-          "{
-            "mcpServers": {
-              "glean": {
-                "command": "npx",
-                "args": [
-                  "-y",
-                  "@gleanwork/connect-mcp-server",
-                  "https://test-domain-be.glean.com/mcp/default/sse"
-                ],
-                "env": {
-                  "GLEAN_INSTANCE": "test-domain",
-                  "GLEAN_API_TOKEN": "glean_api_test"
-                }
+        "{
+          "mcpServers": {
+            "glean": {
+              "command": "npx",
+              "args": [
+                "-y",
+                "@gleanwork/connect-mcp-server",
+                "https://test-domain-be.glean.com/mcp/default/sse"
+              ],
+              "type": "stdio",
+              "env": {
+                "GLEAN_INSTANCE": "test-domain",
+                "GLEAN_API_TOKEN": "glean_api_test"
               }
             }
-          }"
-        `);
+          }
+        }"
+      `);
     });
 
     it('configures the default mcp server', async () => {
@@ -1224,23 +1287,24 @@ Error configuring client: API token is required. Please provide a token with the
 
       expect(fs.existsSync(configFilePath)).toBe(true);
       expect(configFileContents).toMatchInlineSnapshot(`
-          "{
-            "mcpServers": {
-              "glean": {
-                "command": "npx",
-                "args": [
-                  "-y",
-                  "@gleanwork/connect-mcp-server",
-                  "https://test-domain-be.glean.com/mcp/default/sse"
-                ],
-                "env": {
-                  "GLEAN_INSTANCE": "test-domain",
-                  "GLEAN_API_TOKEN": "glean_api_test"
-                }
+        "{
+          "mcpServers": {
+            "glean": {
+              "command": "npx",
+              "args": [
+                "-y",
+                "@gleanwork/connect-mcp-server",
+                "https://test-domain-be.glean.com/mcp/default/sse"
+              ],
+              "type": "stdio",
+              "env": {
+                "GLEAN_INSTANCE": "test-domain",
+                "GLEAN_API_TOKEN": "glean_api_test"
               }
             }
-          }"
-        `);
+          }
+        }"
+      `);
     });
 
     it('configures the agents mcp server', async () => {
@@ -1292,6 +1356,7 @@ Error configuring client: API token is required. Please provide a token with the
                 "@gleanwork/connect-mcp-server",
                 "https://test-domain-be.glean.com/mcp/agents/sse"
               ],
+              "type": "stdio",
               "env": {
                 "GLEAN_INSTANCE": "test-domain",
                 "GLEAN_API_TOKEN": "glean_api_test"
@@ -1389,6 +1454,7 @@ Error configuring client: API token is required. Please provide a token with the
                 "GLEAN_API_TOKEN": "test-token",
                 "GLEAN_INSTANCE": "test-instance",
               },
+              "type": "stdio",
             },
           },
         }
@@ -1448,6 +1514,7 @@ Error configuring client: API token is required. Please provide a token with the
                 "GLEAN_API_TOKEN": "env-token",
                 "GLEAN_INSTANCE": "env-instance",
               },
+              "type": "stdio",
             },
           },
         }
@@ -1480,6 +1547,7 @@ Error configuring client: API token is required. Please provide a token with the
                 "GLEAN_API_TOKEN": "process-env-token",
                 "GLEAN_INSTANCE": "process-env-instance",
               },
+              "type": "stdio",
             },
           },
         }
@@ -1525,6 +1593,7 @@ Error configuring client: API token is required. Please provide a token with the
                 "GLEAN_API_TOKEN": "flag-token",
                 "GLEAN_INSTANCE": "flag-instance",
               },
+              "type": "stdio",
             },
           },
         }
@@ -1615,6 +1684,7 @@ Error configuring client: API token is required. Please provide a token with the
                   "@gleanwork/connect-mcp-server",
                   "https://test-domain-be.glean.com/mcp/default/sse"
                 ],
+                "type": "stdio",
                 "env": {
                   "GLEAN_INSTANCE": "test-domain",
                   "GLEAN_API_TOKEN": "glean_api_test"
@@ -1688,6 +1758,7 @@ Error configuring client: API token is required. Please provide a token with the
                   "@gleanwork/connect-mcp-server",
                   "https://test-domain-be.glean.com/mcp/default/sse"
                 ],
+                "type": "stdio",
                 "env": {
                   "GLEAN_INSTANCE": "test-domain",
                   "GLEAN_API_TOKEN": "glean_api_test"
@@ -1759,6 +1830,7 @@ Error configuring client: API token is required. Please provide a token with the
                   "@gleanwork/connect-mcp-server",
                   "https://test-domain-be.glean.com/mcp/default/sse"
                 ],
+                "type": "stdio",
                 "env": {
                   "GLEAN_INSTANCE": "test-domain",
                   "GLEAN_API_TOKEN": "glean_api_test"
@@ -1766,6 +1838,81 @@ Error configuring client: API token is required. Please provide a token with the
               }
             }
           }"
+        `);
+      });
+
+      it('configures both default and agents remote servers', async () => {
+        // First, configure the default remote server
+        const result1 = await runBin(
+          'remote',
+          '--client',
+          'cursor',
+          '--token',
+          'glean_api_test',
+          '--instance',
+          'test-domain',
+          {
+            env: {
+              GLEAN_MCP_CONFIG_DIR: project.baseDir,
+            },
+          },
+        );
+
+        expect(result1.exitCode).toEqual(0);
+
+        // Then, add the agents remote server to the same config
+        const result2 = await runBin(
+          'remote',
+          '--client',
+          'cursor',
+          '--agents',
+          '--token',
+          'glean_api_test',
+          '--instance',
+          'test-domain',
+          {
+            env: {
+              GLEAN_MCP_CONFIG_DIR: project.baseDir,
+            },
+          },
+        );
+
+        expect(result2.exitCode).toEqual(0);
+
+        // Verify both servers are configured
+        const configFileContents = fs.readFileSync(configFilePath, 'utf8');
+        const parsedConfig = JSON.parse(configFileContents);
+        expect(parsedConfig).toMatchInlineSnapshot(`
+          {
+            "mcpServers": {
+              "glean": {
+                "args": [
+                  "-y",
+                  "@gleanwork/connect-mcp-server",
+                  "https://test-domain-be.glean.com/mcp/default/sse",
+                ],
+                "command": "npx",
+                "env": {
+                  "GLEAN_API_TOKEN": "glean_api_test",
+                  "GLEAN_INSTANCE": "test-domain",
+                },
+                "type": "stdio",
+              },
+              "glean_agents": {
+                "args": [
+                  "-y",
+                  "@gleanwork/connect-mcp-server",
+                  "https://test-domain-be.glean.com/mcp/agents/sse",
+                ],
+                "command": "npx",
+                "env": {
+                  "GLEAN_API_TOKEN": "glean_api_test",
+                  "GLEAN_INSTANCE": "test-domain",
+                },
+                "type": "stdio",
+              },
+            },
+          }
         `);
       });
     });
@@ -1829,6 +1976,7 @@ Error configuring client: API token is required. Please provide a token with the
                   "@gleanwork/connect-mcp-server",
                   "https://test-domain-be.glean.com/mcp/default/sse"
                 ],
+                "type": "stdio",
                 "env": {
                   "GLEAN_INSTANCE": "test-domain",
                   "GLEAN_API_TOKEN": "glean_api_test"
@@ -1904,6 +2052,7 @@ Error configuring client: API token is required. Please provide a token with the
                   "@gleanwork/connect-mcp-server",
                   "https://test-domain-be.glean.com/mcp/default/sse"
                 ],
+                "type": "stdio",
                 "env": {
                   "GLEAN_INSTANCE": "test-domain",
                   "GLEAN_API_TOKEN": "glean_api_test"
@@ -1975,6 +2124,7 @@ Error configuring client: API token is required. Please provide a token with the
                   "@gleanwork/connect-mcp-server",
                   "https://test-domain-be.glean.com/mcp/default/sse"
                 ],
+                "type": "stdio",
                 "env": {
                   "GLEAN_INSTANCE": "test-domain",
                   "GLEAN_API_TOKEN": "glean_api_test"
@@ -1982,6 +2132,81 @@ Error configuring client: API token is required. Please provide a token with the
               }
             }
           }"
+        `);
+      });
+
+      it('configures both default and agents remote servers', async () => {
+        // First, configure the default remote server
+        const result1 = await runBin(
+          'remote',
+          '--client',
+          'claude',
+          '--token',
+          'glean_api_test',
+          '--instance',
+          'test-domain',
+          {
+            env: {
+              GLEAN_MCP_CONFIG_DIR: project.baseDir,
+            },
+          },
+        );
+
+        expect(result1.exitCode).toEqual(0);
+
+        // Then, add the agents remote server to the same config
+        const result2 = await runBin(
+          'remote',
+          '--client',
+          'claude',
+          '--agents',
+          '--token',
+          'glean_api_test',
+          '--instance',
+          'test-domain',
+          {
+            env: {
+              GLEAN_MCP_CONFIG_DIR: project.baseDir,
+            },
+          },
+        );
+
+        expect(result2.exitCode).toEqual(0);
+
+        // Verify both servers are configured
+        const configFileContents = fs.readFileSync(configFilePath, 'utf8');
+        const parsedConfig = JSON.parse(configFileContents);
+        expect(parsedConfig).toMatchInlineSnapshot(`
+          {
+            "mcpServers": {
+              "glean": {
+                "args": [
+                  "-y",
+                  "@gleanwork/connect-mcp-server",
+                  "https://test-domain-be.glean.com/mcp/default/sse",
+                ],
+                "command": "npx",
+                "env": {
+                  "GLEAN_API_TOKEN": "glean_api_test",
+                  "GLEAN_INSTANCE": "test-domain",
+                },
+                "type": "stdio",
+              },
+              "glean_agents": {
+                "args": [
+                  "-y",
+                  "@gleanwork/connect-mcp-server",
+                  "https://test-domain-be.glean.com/mcp/agents/sse",
+                ],
+                "command": "npx",
+                "env": {
+                  "GLEAN_API_TOKEN": "glean_api_test",
+                  "GLEAN_INSTANCE": "test-domain",
+                },
+                "type": "stdio",
+              },
+            },
+          }
         `);
       });
     });
@@ -2046,6 +2271,7 @@ Error configuring client: API token is required. Please provide a token with the
                   "@gleanwork/connect-mcp-server",
                   "https://test-domain-be.glean.com/mcp/default/sse"
                 ],
+                "type": "stdio",
                 "env": {
                   "GLEAN_INSTANCE": "test-domain",
                   "GLEAN_API_TOKEN": "glean_api_test"
@@ -2120,6 +2346,7 @@ Error configuring client: API token is required. Please provide a token with the
                   "@gleanwork/connect-mcp-server",
                   "https://test-domain-be.glean.com/mcp/default/sse"
                 ],
+                "type": "stdio",
                 "env": {
                   "GLEAN_INSTANCE": "test-domain",
                   "GLEAN_API_TOKEN": "glean_api_test"
@@ -2192,6 +2419,7 @@ Error configuring client: API token is required. Please provide a token with the
                   "@gleanwork/connect-mcp-server",
                   "https://test-domain-be.glean.com/mcp/default/sse"
                 ],
+                "type": "stdio",
                 "env": {
                   "GLEAN_INSTANCE": "test-domain",
                   "GLEAN_API_TOKEN": "glean_api_test"
@@ -2199,6 +2427,81 @@ Error configuring client: API token is required. Please provide a token with the
               }
             }
           }"
+        `);
+      });
+
+      it('configures both default and agents remote servers', async () => {
+        // First, configure the default remote server
+        const result1 = await runBin(
+          'remote',
+          '--client',
+          'windsurf',
+          '--token',
+          'glean_api_test',
+          '--instance',
+          'test-domain',
+          {
+            env: {
+              GLEAN_MCP_CONFIG_DIR: project.baseDir,
+            },
+          },
+        );
+
+        expect(result1.exitCode).toEqual(0);
+
+        // Then, add the agents remote server to the same config
+        const result2 = await runBin(
+          'remote',
+          '--client',
+          'windsurf',
+          '--agents',
+          '--token',
+          'glean_api_test',
+          '--instance',
+          'test-domain',
+          {
+            env: {
+              GLEAN_MCP_CONFIG_DIR: project.baseDir,
+            },
+          },
+        );
+
+        expect(result2.exitCode).toEqual(0);
+
+        // Verify both servers are configured
+        const configFileContents = fs.readFileSync(configFilePath, 'utf8');
+        const parsedConfig = JSON.parse(configFileContents);
+        expect(parsedConfig).toMatchInlineSnapshot(`
+          {
+            "mcpServers": {
+              "glean": {
+                "args": [
+                  "-y",
+                  "@gleanwork/connect-mcp-server",
+                  "https://test-domain-be.glean.com/mcp/default/sse",
+                ],
+                "command": "npx",
+                "env": {
+                  "GLEAN_API_TOKEN": "glean_api_test",
+                  "GLEAN_INSTANCE": "test-domain",
+                },
+                "type": "stdio",
+              },
+              "glean_agents": {
+                "args": [
+                  "-y",
+                  "@gleanwork/connect-mcp-server",
+                  "https://test-domain-be.glean.com/mcp/agents/sse",
+                ],
+                "command": "npx",
+                "env": {
+                  "GLEAN_API_TOKEN": "glean_api_test",
+                  "GLEAN_INSTANCE": "test-domain",
+                },
+                "type": "stdio",
+              },
+            },
+          }
         `);
       });
     });
@@ -2272,25 +2575,26 @@ Error configuring client: API token is required. Please provide a token with the
         // Normalize JSON to avoid platform-specific escaping issues
         const parsedContents = JSON.parse(configFileContents);
         expect(parsedContents).toMatchInlineSnapshot(`
-        {
-          "mcp": {
-            "servers": {
-              "glean": {
-                "args": [
-                  "-y",
-                  "@gleanwork/local-mcp-server",
-                ],
-                "command": "npx",
-                "env": {
-                  "GLEAN_API_TOKEN": "glean_api_test",
-                  "GLEAN_INSTANCE": "test-domain",
+          {
+            "mcp": {
+              "servers": {
+                "glean": {
+                  "args": [
+                    "-y",
+                    "@gleanwork/connect-mcp-server",
+                    "https://test-domain-be.glean.com/mcp/default/sse",
+                  ],
+                  "command": "npx",
+                  "env": {
+                    "GLEAN_API_TOKEN": "glean_api_test",
+                    "GLEAN_INSTANCE": "test-domain",
+                  },
+                  "type": "stdio",
                 },
-                "type": "stdio",
               },
             },
-          },
-        }
-      `);
+          }
+        `);
       });
 
       it("adds config to existing file that doesn't have Glean config", async () => {
@@ -2332,27 +2636,28 @@ Error configuring client: API token is required. Please provide a token with the
         const parsedConfig = JSON.parse(configFileContents);
 
         expect(parsedConfig).toMatchInlineSnapshot(`
-        {
-          "editor.fontSize": 14,
-          "mcp": {
-            "servers": {
-              "glean": {
-                "args": [
-                  "-y",
-                  "@gleanwork/local-mcp-server",
-                ],
-                "command": "npx",
-                "env": {
-                  "GLEAN_API_TOKEN": "glean_api_test",
-                  "GLEAN_INSTANCE": "test-domain",
+          {
+            "editor.fontSize": 14,
+            "mcp": {
+              "servers": {
+                "glean": {
+                  "args": [
+                    "-y",
+                    "@gleanwork/connect-mcp-server",
+                    "https://test-domain-be.glean.com/mcp/default/sse",
+                  ],
+                  "command": "npx",
+                  "env": {
+                    "GLEAN_API_TOKEN": "glean_api_test",
+                    "GLEAN_INSTANCE": "test-domain",
+                  },
+                  "type": "stdio",
                 },
-                "type": "stdio",
               },
             },
-          },
-          "workbench.colorTheme": "Default Dark+",
-        }
-      `);
+            "workbench.colorTheme": "Default Dark+",
+          }
+        `);
       });
 
       it('updates configurations from local to remote', async () => {
@@ -2409,12 +2714,13 @@ Error configuring client: API token is required. Please provide a token with the
             "mcp": {
               "servers": {
                 "glean": {
-                  "type": "stdio",
                   "command": "npx",
                   "args": [
                     "-y",
-                    "@gleanwork/local-mcp-server"
+                    "@gleanwork/connect-mcp-server",
+                    "https://test-domain-be.glean.com/mcp/default/sse"
                   ],
+                  "type": "stdio",
                   "env": {
                     "GLEAN_INSTANCE": "test-domain",
                     "GLEAN_API_TOKEN": "glean_api_test"
@@ -2423,6 +2729,89 @@ Error configuring client: API token is required. Please provide a token with the
               }
             }
           }"
+        `);
+      });
+
+      it('configures both default and agents remote servers', async () => {
+        // First, configure the default remote server
+        const result1 = await runBin(
+          'remote',
+          '--client',
+          'vscode',
+          '--token',
+          'glean_api_test',
+          '--instance',
+          'test-domain',
+          {
+            env: {
+              GLEAN_MCP_CONFIG_DIR: project.baseDir,
+              HOME: project.baseDir,
+              USERPROFILE: project.baseDir,
+              APPDATA: project.baseDir,
+            },
+          },
+        );
+
+        expect(result1.exitCode).toEqual(0);
+
+        // Then, add the agents remote server to the same config
+        const result2 = await runBin(
+          'remote',
+          '--client',
+          'vscode',
+          '--agents',
+          '--token',
+          'glean_api_test',
+          '--instance',
+          'test-domain',
+          {
+            env: {
+              GLEAN_MCP_CONFIG_DIR: project.baseDir,
+              HOME: project.baseDir,
+              USERPROFILE: project.baseDir,
+              APPDATA: project.baseDir,
+            },
+          },
+        );
+
+        expect(result2.exitCode).toEqual(0);
+
+        // Verify both servers are configured
+        const configFileContents = fs.readFileSync(configFilePath, 'utf8');
+        const parsedConfig = JSON.parse(configFileContents);
+        expect(parsedConfig).toMatchInlineSnapshot(`
+          {
+            "mcp": {
+              "servers": {
+                "glean": {
+                  "args": [
+                    "-y",
+                    "@gleanwork/connect-mcp-server",
+                    "https://test-domain-be.glean.com/mcp/default/sse",
+                  ],
+                  "command": "npx",
+                  "env": {
+                    "GLEAN_API_TOKEN": "glean_api_test",
+                    "GLEAN_INSTANCE": "test-domain",
+                  },
+                  "type": "stdio",
+                },
+                "glean_agents": {
+                  "args": [
+                    "-y",
+                    "@gleanwork/connect-mcp-server",
+                    "https://test-domain-be.glean.com/mcp/agents/sse",
+                  ],
+                  "command": "npx",
+                  "env": {
+                    "GLEAN_API_TOKEN": "glean_api_test",
+                    "GLEAN_INSTANCE": "test-domain",
+                  },
+                  "type": "stdio",
+                },
+              },
+            },
+          }
         `);
       });
     });

--- a/packages/configure-mcp-server/src/test/configure.test.ts
+++ b/packages/configure-mcp-server/src/test/configure.test.ts
@@ -99,6 +99,7 @@ describe('configure', () => {
               "GLEAN_API_TOKEN": "test-token",
               "GLEAN_INSTANCE": "test-instance",
             },
+            "type": "stdio",
           },
         },
       }
@@ -131,6 +132,7 @@ describe('configure', () => {
               "GLEAN_API_TOKEN": "test-token",
               "GLEAN_BASE_URL": "https://example.com/rest/api/v1",
             },
+            "type": "stdio",
           },
         },
       }
@@ -161,6 +163,7 @@ describe('configure', () => {
               "GLEAN_API_TOKEN": "env-token",
               "GLEAN_INSTANCE": "env-instance",
             },
+            "type": "stdio",
           },
         },
       }
@@ -191,6 +194,7 @@ describe('configure', () => {
               "GLEAN_API_TOKEN": "env-file-token",
               "GLEAN_INSTANCE": "env-file-instance",
             },
+            "type": "stdio",
           },
         },
       }
@@ -227,6 +231,7 @@ describe('configure', () => {
             "env": {
               "GLEAN_INSTANCE": "test-instance",
             },
+            "type": "stdio",
           },
         },
       }
@@ -264,6 +269,7 @@ describe('configure', () => {
             "env": {
               "GLEAN_INSTANCE": "test-instance",
             },
+            "type": "stdio",
           },
         },
       }

--- a/packages/configure-mcp-server/src/test/configure/vscode.test.ts
+++ b/packages/configure-mcp-server/src/test/configure/vscode.test.ts
@@ -81,24 +81,29 @@ describe('VS Code MCP Client', () => {
       'test-token',
     );
 
-    expect(config).toMatchObject({
-      mcp: {
-        servers: {
-          glean: {
-            type: 'stdio',
-            command: 'npx',
-            args: ['-y', '@gleanwork/local-mcp-server'],
-            env: {
-              GLEAN_INSTANCE: 'example-instance',
-              GLEAN_API_TOKEN: 'test-token',
+    expect(config).toMatchInlineSnapshot(`
+      {
+        "mcp": {
+          "servers": {
+            "glean_local": {
+              "args": [
+                "-y",
+                "@gleanwork/local-mcp-server",
+              ],
+              "command": "npx",
+              "env": {
+                "GLEAN_API_TOKEN": "test-token",
+                "GLEAN_INSTANCE": "example-instance",
+              },
+              "type": "stdio",
             },
           },
         },
-      },
-    });
+      }
+    `)
   });
 
-  it('should generate a valid VS Code workspace config template with instance', () => {
+  it('should generate a valid VS Code workspace config template with instance (local)', () => {
     const options: ConfigureOptions = { workspace: true };
     const config = vscodeClient.configTemplate(
       'example-instance',
@@ -106,19 +111,82 @@ describe('VS Code MCP Client', () => {
       options,
     );
 
-    expect(config).toMatchObject({
-      servers: {
-        glean: {
-          type: 'stdio',
-          command: 'npx',
-          args: ['-y', '@gleanwork/local-mcp-server'],
-          env: {
-            GLEAN_INSTANCE: 'example-instance',
-            GLEAN_API_TOKEN: 'test-token',
+    expect(config).toMatchInlineSnapshot(`
+      {
+        "servers": {
+          "glean_local": {
+            "args": [
+              "-y",
+              "@gleanwork/local-mcp-server",
+            ],
+            "command": "npx",
+            "env": {
+              "GLEAN_API_TOKEN": "test-token",
+              "GLEAN_INSTANCE": "example-instance",
+            },
+            "type": "stdio",
           },
         },
-      },
-    });
+      }
+    `)
+  });
+
+  it('should generate a valid VS Code workspace config template with instance (remote: default)', () => {
+    const options: ConfigureOptions = { workspace: true, remote: true };
+    const config = vscodeClient.configTemplate(
+      'example-instance',
+      'test-token',
+      options,
+    );
+
+    expect(config).toMatchInlineSnapshot(`
+      {
+        "servers": {
+          "glean": {
+            "args": [
+              "-y",
+              "@gleanwork/connect-mcp-server",
+              "https://example-instance-be.glean.com/mcp/default/sse",
+            ],
+            "command": "npx",
+            "env": {
+              "GLEAN_API_TOKEN": "test-token",
+              "GLEAN_INSTANCE": "example-instance",
+            },
+            "type": "stdio",
+          },
+        },
+      }
+    `)
+  });
+
+  it('should generate a valid VS Code workspace config template with instance (remote: agents)', () => {
+    const options: ConfigureOptions = { workspace: true, remote: true, agents: true };
+    const config = vscodeClient.configTemplate(
+      'example-instance',
+      'test-token',
+      options,
+    );
+
+    expect(config).toMatchInlineSnapshot(`
+      {
+        "servers": {
+          "glean_agents": {
+            "args": [
+              "-y",
+              "@gleanwork/connect-mcp-server",
+              "https://example-instance-be.glean.com/mcp/agents/sse",
+            ],
+            "command": "npx",
+            "env": {
+              "GLEAN_API_TOKEN": "test-token",
+              "GLEAN_INSTANCE": "example-instance",
+            },
+            "type": "stdio",
+          },
+        },
+      }
+    `)
   });
 
   it('should generate a valid VS Code MCP config template with URL', () => {
@@ -127,18 +195,26 @@ describe('VS Code MCP Client', () => {
       'test-token',
     );
 
-    expect(config).toMatchObject({
-      mcp: {
-        servers: {
-          glean: {
-            env: {
-              GLEAN_BASE_URL: 'https://example.com/rest/api/v1',
-              GLEAN_API_TOKEN: 'test-token',
+    expect(config).toMatchInlineSnapshot(`
+      {
+        "mcp": {
+          "servers": {
+            "glean_local": {
+              "args": [
+                "-y",
+                "@gleanwork/local-mcp-server",
+              ],
+              "command": "npx",
+              "env": {
+                "GLEAN_API_TOKEN": "test-token",
+                "GLEAN_BASE_URL": "https://example.com/rest/api/v1",
+              },
+              "type": "stdio",
             },
           },
         },
-      },
-    });
+      }
+    `);
   });
 
   it('should include success message with instructions', () => {
@@ -163,6 +239,7 @@ describe('VS Code MCP Client', () => {
     );
     expect(message).toContain(configPath);
   });
+
   it('should update global config correctly', () => {
     const existingConfig = { someOtherConfig: true };
     const newConfig: MCPConfig = {
@@ -218,19 +295,24 @@ describe('VS Code MCP Client', () => {
       options,
     );
 
-    expect(config).toMatchObject({
-      servers: {
-        glean: {
-          type: 'stdio',
-          command: 'npx',
-          args: ['-y', '@gleanwork/local-mcp-server'],
-          env: {
-            GLEAN_BASE_URL: 'https://example.com/rest/api/v1',
-            GLEAN_API_TOKEN: 'test-token',
+    expect(config).toMatchInlineSnapshot(`
+      {
+        "servers": {
+          "glean_local": {
+            "args": [
+              "-y",
+              "@gleanwork/local-mcp-server",
+            ],
+            "command": "npx",
+            "env": {
+              "GLEAN_API_TOKEN": "test-token",
+              "GLEAN_BASE_URL": "https://example.com/rest/api/v1",
+            },
+            "type": "stdio",
           },
         },
-      },
-    });
+      }
+    `)
   });
 
   it('should generate global config when workspace option is false', () => {
@@ -241,20 +323,25 @@ describe('VS Code MCP Client', () => {
       options,
     );
 
-    expect(config).toMatchObject({
-      mcp: {
-        servers: {
-          glean: {
-            type: 'stdio',
-            command: 'npx',
-            args: ['-y', '@gleanwork/local-mcp-server'],
-            env: {
-              GLEAN_INSTANCE: 'example-instance',
-              GLEAN_API_TOKEN: 'test-token',
+    expect(config).toMatchInlineSnapshot(`
+      {
+        "mcp": {
+          "servers": {
+            "glean_local": {
+              "args": [
+                "-y",
+                "@gleanwork/local-mcp-server",
+              ],
+              "command": "npx",
+              "env": {
+                "GLEAN_API_TOKEN": "test-token",
+                "GLEAN_INSTANCE": "example-instance",
+              },
+              "type": "stdio",
             },
           },
         },
-      },
-    });
+      }
+    `)
   });
 });


### PR DESCRIPTION
configure/client/vscode.ts reimplemented a lot of the base client configuration.  This was missed in the initial implementation of remote support.

Factor the common functionality into `createMcpServersConfig` since the main difference was where the mcp servers lived (`mcpServers` vs `mcp.servers`).  Part of this unification means adding `type: "stdio"` to all configs.

Also add tests that validate running the CLI back to back can add the default and agents MCP servers without causing issues.

Finally, updated the "doesn't break existing configs" tests to have existing mcp servers in addition to existing other config and validate that we don't break those.
