### PR TITLE
fix(build): explicitly set rootDir

### DIFF
--- a/packages/configure-mcp-server/tsconfig.json
+++ b/packages/configure-mcp-server/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es2017",
     "module": "nodenext",
     "lib": ["es2022"],
+    "rootDir": "./src",
     "outDir": "./build",
     "declaration": true,
     "declarationMap": true,

--- a/packages/local-mcp-server/tsconfig.json
+++ b/packages/local-mcp-server/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es2017",
     "module": "nodenext",
     "lib": ["es2022"],
+    "rootDir": "./src",
     "outDir": "./build",
     "declaration": true,
     "declarationMap": true,

--- a/packages/mcp-server-utils/tsconfig.json
+++ b/packages/mcp-server-utils/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es2017",
     "module": "nodenext",
     "lib": ["es2022"],
+    "rootDir": "./src",
     "outDir": "./build",
     "declaration": true,
     "declarationMap": true,

--- a/packages/mcp-test-utils/tsconfig.json
+++ b/packages/mcp-test-utils/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es2017",
     "module": "nodenext",
     "lib": ["es2022"],
+    "rootDir": "./src",
     "outDir": "./build",
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
Without a rootDir in tsconfig the default behaviour is to strip the longest common path of all non-declaration input files.  This led to build failures in #188 because `mcp-test-utils/src` had no `.ts` files so the discovered root was `src/mocks` not `src`.

see <https://www.typescriptlang.org/tsconfig/#rootDir>
