### PR TITLE
Refactor goose client config

### DIFF
--- a/packages/configure-mcp-server/package.json
+++ b/packages/configure-mcp-server/package.json
@@ -51,9 +51,9 @@
     "meow": "^13.2.0",
     "open": "^10.1.1",
     "tldts": "^7.0.7",
+    "yaml": "^2.8.0",
     "zod": "^3.25.65",
-    "zod-to-json-schema": "^3.24.5",
-    "yaml": "^2.8.0"
+    "zod-to-json-schema": "^3.24.5"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",

--- a/packages/configure-mcp-server/src/configure/client/index.ts
+++ b/packages/configure-mcp-server/src/configure/client/index.ts
@@ -265,6 +265,10 @@ export function createBaseClient(
   configPath: MCPConfigPath,
   instructions: string[],
   pathResolverOverride?: (homedir: string) => string,
+  mcpServersHook: (
+    servers: MCPServersConfig,
+    options?: ConfigureOptions,
+  ) => MCPConfig = (servers) => ({ mcpServers: servers }),
 ): MCPClientConfig {
   return {
     displayName,
@@ -272,7 +276,18 @@ export function createBaseClient(
     configFilePath:
       pathResolverOverride || createStandardPathResolver(configPath),
 
-    configTemplate: createConfigTemplate,
+    configTemplate: (
+      instanceOrUrl?: string,
+      apiToken?: string,
+      options?: ConfigureOptions,
+    ) => {
+      const servers = createMcpServersConfig(
+        instanceOrUrl,
+        apiToken,
+        options,
+      );
+      return mcpServersHook(servers, options);
+    },
 
     successMessage: (configPath) =>
       createSuccessMessage(displayName, configPath, instructions),


### PR DESCRIPTION
## Summary
- add hook to `createBaseClient` for mutating MCP server config
- rework Goose configuration to use `createBaseClient` with the hook

## Testing
- `pnpm -r test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855b788f4bc8327928078fea94e0a3d