### PR TITLE
Remove casts from Claude Code client

### DIFF
--- a/packages/configure-mcp-server/src/configure/client/claude-code.ts
+++ b/packages/configure-mcp-server/src/configure/client/claude-code.ts
@@ -5,14 +5,7 @@
  */
 
 import path from 'path';
-import {
-  MCPConfigPath,
-  createBaseClient,
-  updateMcpServersConfig,
-  MCPServersConfig,
-  ConfigFileContents,
-  MCPConfig,
-} from './index.js';
+import { MCPConfigPath, createBaseClient } from './index.js';
 
 export const claudeCodeConfigPath: MCPConfigPath = {
   configDir: '',
@@ -33,12 +26,6 @@ function claudeCodePathResolver(homedir: string) {
   return path.join(baseDir, claudeCodeConfigPath.configFileName);
 }
 
-function mcpServersHook(servers: MCPServersConfig): MCPConfig {
-  return {
-    'mcpServers': servers,
-  } as unknown as MCPConfig;
-}
-
 const claudeCodeClient = createBaseClient(
   'Claude Code',
   claudeCodeConfigPath,
@@ -46,19 +33,6 @@ const claudeCodeClient = createBaseClient(
     'Run `claude mcp list` and verify the server is listed',
   ],
   claudeCodePathResolver,
-  mcpServersHook,
 );
-
-claudeCodeClient.updateConfig = (
-  existingConfig: ConfigFileContents,
-  newConfig: MCPConfig,
-) => {
-  const result = { ...existingConfig } as ConfigFileContents & {
-    'mcpServers': MCPServersConfig;
-  };
-  const newServers = (newConfig as any)['mcpServers'];
-  result['mcpServers'] = updateMcpServersConfig(result['mcpServers'] || {}, newServers);
-  return result;
-};
 
 export default claudeCodeClient;


### PR DESCRIPTION
## Summary
- clean up Claude Code client to match other client implementations
- remove `as` casts and rely on `createBaseClient`

## Testing
- `pnpm --filter @gleanwork/configure-mcp-server test` *(fails: interactive tests require network access)*

------
https://chatgpt.com/codex/tasks/task_e_6859e6a84948832799dcf3651870d49d