### PR TITLE
Remove casts from Claude Code client

### DIFF
--- a/packages/configure-mcp-server/src/configure/client/claude-code.ts
+++ b/packages/configure-mcp-server/src/configure/client/claude-code.ts
@@ -8,10 +8,8 @@ import path from 'path';
 import {
   MCPConfigPath,
   createBaseClient,
-  updateMcpServersConfig,
   MCPServersConfig,
-  ConfigFileContents,
-  MCPConfig,
+  StandardMCPConfig,
 } from './index.js';
 
 export const claudeCodeConfigPath: MCPConfigPath = {
@@ -33,10 +31,10 @@ function claudeCodePathResolver(homedir: string) {
   return path.join(baseDir, claudeCodeConfigPath.configFileName);
 }
 
-function mcpServersHook(servers: MCPServersConfig): MCPConfig {
+function mcpServersHook(servers: MCPServersConfig): StandardMCPConfig {
   return {
-    'mcpServers': servers,
-  } as unknown as MCPConfig;
+    mcpServers: servers,
+  };
 }
 
 const claudeCodeClient = createBaseClient(
@@ -49,16 +47,5 @@ const claudeCodeClient = createBaseClient(
   mcpServersHook,
 );
 
-claudeCodeClient.updateConfig = (
-  existingConfig: ConfigFileContents,
-  newConfig: MCPConfig,
-) => {
-  const result = { ...existingConfig } as ConfigFileContents & {
-    'mcpServers': MCPServersConfig;
-  };
-  const newServers = (newConfig as any)['mcpServers'];
-  result['mcpServers'] = updateMcpServersConfig(result['mcpServers'] || {}, newServers);
-  return result;
-};
 
 export default claudeCodeClient;


### PR DESCRIPTION
## Summary
- clean up Claude Code client
- rely on base client update logic without extra casts

## Testing
- `pnpm -r lint:ts`
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_b_685ae6114a388322959e7187dd3f1b97