### PR TITLE
Remove support email

### DIFF
--- a/packages/local-mcp-server/README.md
+++ b/packages/local-mcp-server/README.md
@@ -90,4 +90,3 @@ MIT License - see the [LICENSE](LICENSE) file for details
 
 - Documentation: [docs.glean.com](https://docs.glean.com)
 - Issues: [GitHub Issues](https://github.com/gleanwork/mcp-server/issues)
-- Email: [support@glean.com](mailto:support@glean.com)


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file in `packages/local-mcp-server`. The change removes the support email link from the "Contact" section.