### PR TITLE
fix: related docs

### DIFF
--- a/packages/local-mcp-server/package.json
+++ b/packages/local-mcp-server/package.json
@@ -50,7 +50,7 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@gleanwork/api-client": "0.6.7",
+    "@gleanwork/api-client": "0.7.1",
     "@gleanwork/mcp-server-utils": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.12.3",
     "dotenv": "^17.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,8 +139,8 @@ importers:
   packages/local-mcp-server:
     dependencies:
       '@gleanwork/api-client':
-        specifier: 0.6.7
-        version: 0.6.7(zod@3.25.67)
+        specifier: 0.7.1
+        version: 0.7.1(zod@3.25.67)
       '@gleanwork/mcp-server-utils':
         specifier: workspace:*
         version: link:../mcp-server-utils
@@ -797,6 +797,21 @@ packages:
 
   '@gleanwork/api-client@0.6.7':
     resolution: {integrity: sha512-seZq0f797RFFOkAcyqEje09zIvyK4eW3ByjUtimVcwLYwJJTKQ1LITNGwsmCOKLwQPyQtrIJXzvlKaSr1jLxKw==}
+    peerDependencies:
+      '@tanstack/react-query': ^5
+      react: ^18 || ^19
+      react-dom: ^18 || ^19
+      zod: '>= 3'
+    peerDependenciesMeta:
+      '@tanstack/react-query':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  '@gleanwork/api-client@0.7.1':
+    resolution: {integrity: sha512-cqg+bBBn6kNwe2yg6QMfTDtcuRMNCREccIDV14av/0FwTnMzrroUvNnBEStQoiSeRCB32/nKrG/GIAyxBXTPTA==}
     peerDependencies:
       '@tanstack/react-query': ^5
       react: ^18 || ^19
@@ -4588,6 +4603,10 @@ snapshots:
   '@gar/promisify@1.1.3': {}
 
   '@gleanwork/api-client@0.6.7(zod@3.25.67)':
+    dependencies:
+      zod: 3.25.67
+
+  '@gleanwork/api-client@0.7.1(zod@3.25.67)':
     dependencies:
       zod: 3.25.67
 


### PR DESCRIPTION
Document search fails when certain related documents come back.  This is because relation types like "contact" can come back lowercase even though the openapi spec has it uppercase.

This is fixed in 0.7 of the api client by including both values in the enum.
