### PR TITLE
Fix path normalization in tests

### DIFF
--- a/packages/configure-mcp-server/src/test/cli.test.ts
+++ b/packages/configure-mcp-server/src/test/cli.test.ts
@@ -17,7 +17,9 @@ function normalizeOutput(output: string, baseDir: string): string {
   let normalized = normalizeBaseDirOutput(output, baseDir);
   normalized = normalizeVersionOutput(normalized);
   normalized = normalizeVSCodeConfigPath(normalized);
-  normalized = normalizePathSeparators(normalized);
+  if (process.platform === 'win32') {
+    normalized = normalizePathSeparators(normalized);
+  }
 
   return normalized;
 }


### PR DESCRIPTION
## Summary
- normalize paths in snapshot tests

## Testing
- `pnpm --filter @gleanwork/configure-mcp-server test`


------
https://chatgpt.com/codex/tasks/task_b_6876a904d54c83229870e883bf1d648c