### PR TITLE
Add support for onelogin device flow

### DIFF
--- a/packages/configure-mcp-server/package.json
+++ b/packages/configure-mcp-server/package.json
@@ -34,6 +34,7 @@
   ],
   "scripts": {
     "build": "rimraf build && tsc",
+    "go": "tsx src/index.ts",
     "lint": "npm-run-all --sequential lint:*",
     "lint:eslint": "eslint \"src/**/*.ts\" --fix",
     "lint:package-json": "sort-package-json",
@@ -74,6 +75,7 @@
     "npm-run-all": "^4.1.5",
     "rimraf": "^6.0.1",
     "sort-package-json": "^3.4.0",
+    "tsx": "^4.20.3",
     "typescript": "^5.8.2",
     "vitest": "^3.2.3"
   },

--- a/packages/mcp-server-utils/src/config/index.ts
+++ b/packages/mcp-server-utils/src/config/index.ts
@@ -55,8 +55,20 @@ interface GleanCommonConfig {
   baseUrl: string;
 }
 
+/**
+ * PKCE fields for device flow with PKCE (e.g. onelogin.com)
+ */
+export interface GleanPkceFields {
+  codeVerifier?: string;
+  codeChallenge?: string;
+  //PKCE code challenge method (usually 'S256')
+  codeChallengeMethod?: string;
+}
 export type GleanTokenConfig = GleanCommonConfig & GleanConfigTokenAccess;
-export type GleanOAuthConfig = GleanCommonConfig & GleanConfigOAuthAccess;
+
+export type GleanOAuthConfig = GleanCommonConfig &
+  GleanConfigOAuthAccess &
+  GleanPkceFields;
 export type GleanBasicConfig = GleanCommonConfig & GleanBasicConfigNoToken;
 
 /**

--- a/packages/mcp-server-utils/src/test/auth/authorize.test.ts
+++ b/packages/mcp-server-utils/src/test/auth/authorize.test.ts
@@ -634,9 +634,6 @@ describe('authorize (device flow)', () => {
   });
 
   it('should complete the device flow with PKCE (OneLogin) and save tokens', async () => {
-    vi.useFakeTimers({
-      now: new Date('2025-07-23T20:31:33.340Z'),
-    });
     const baseUrl = 'https://glean.example.com';
     const issuer = 'https://example.onelogin.com';
     const clientId = 'client-123';
@@ -720,13 +717,18 @@ describe('authorize (device flow)', () => {
     const tokens = await resultPromise;
 
     expect(open).toHaveBeenCalledWith(verificationUri);
-    expect(tokens).toMatchInlineSnapshot(`
-      Tokens {
+    expect(tokens).toMatchInlineSnapshot(
+      {
+        expiresAt: expect.any(Date),
+      },
+      `
+      {
         "accessToken": "access-token-123",
-        "expiresAt": 2025-07-23T20:51:15.925Z,
+        "expiresAt": Any<ClockDate>,
         "refreshToken": "refresh-token-456",
       }
-    `);
+    `,
+    );
     // Tokens file was written and contains correct data
     const tokensFile = path.join(
       process.env.XDG_STATE_HOME!,
@@ -735,14 +737,18 @@ describe('authorize (device flow)', () => {
     );
     expect(fs.existsSync(tokensFile)).toBe(true);
     const fileContent = JSON.parse(fs.readFileSync(tokensFile, 'utf-8'));
-    expect(fileContent).toMatchInlineSnapshot(`
+    expect(fileContent).toMatchInlineSnapshot(
+      {
+        expiresAt: expect.any(String),
+      },
+      `
       {
         "accessToken": "access-token-123",
-        "expiresAt": "2025-07-23T20:51:15.925Z",
+        "expiresAt": Any<String>,
         "refreshToken": "refresh-token-456",
       }
-    `);
-    expect(new Date(fileContent.expiresAt)).toEqual(tokens!.expiresAt);
+    `,
+    );
   });
 
   describe('AbortController integration', () => {

--- a/packages/mcp-server-utils/src/test/auth/authorize.test.ts
+++ b/packages/mcp-server-utils/src/test/auth/authorize.test.ts
@@ -633,6 +633,107 @@ describe('authorize (device flow)', () => {
     );
   });
 
+  it('should complete the device flow with PKCE (OneLogin) and save tokens', async () => {
+    const baseUrl = 'https://glean.example.com';
+    const issuer = 'https://example.onelogin.com';
+    const clientId = 'client-123';
+    const deviceAuthorizationEndpoint =
+      'https://example.onelogin.com/oidc/2/device/auth';
+    const tokenEndpoint = 'https://example.onelogin.com/oidc/2/token';
+    const deviceCode = 'device-code-abc';
+    const userCode = 'user-code-xyz';
+    const verificationUri = 'https://example.onelogin.com/oidc/2/device';
+    const interval = 5; // seconds
+    const expiresIn = 3600;
+    const accessToken = 'access-token-123';
+    const refreshToken = 'refresh-token-456';
+    const codeChallenge = 'test-challenge';
+    const codeChallengeMethod = 'S256';
+    const codeVerifier = 'test-verifier';
+
+    let deviceAuthRequestBody = '';
+    let tokenRequestBody = '';
+
+    server.use(
+      http.get(`${baseUrl}/.well-known/oauth-protected-resource`, () =>
+        HttpResponse.json({
+          authorization_servers: [issuer],
+          glean_device_flow_client_id: clientId,
+        }),
+      ),
+      http.get(`${issuer}/.well-known/openid-configuration`, () =>
+        HttpResponse.json({
+          device_authorization_endpoint: deviceAuthorizationEndpoint,
+          token_endpoint: tokenEndpoint,
+        }),
+      ),
+      http.post(deviceAuthorizationEndpoint, async ({ request }) => {
+        deviceAuthRequestBody = await request.text();
+        console.log('deviceAuthRequestBody', deviceAuthRequestBody);
+        // Check PKCE params in device authorization request
+        expect(deviceAuthRequestBody).toMatch(/code_challenge=.*/);
+        expect(deviceAuthRequestBody).toMatch(/code_challenge_method=S256/);
+        return HttpResponse.json({
+          device_code: deviceCode,
+          user_code: userCode,
+          verification_uri: verificationUri,
+          expires_in: 600,
+          interval,
+        });
+      }),
+      http.post(tokenEndpoint, async ({ request }) => {
+        tokenRequestBody = await request.text();
+        // Check PKCE param in token request
+        expect(tokenRequestBody).toMatch(/code_verifier=.*/);
+        if (tokenRequestBody.includes(`device_code=${deviceCode}`)) {
+          return HttpResponse.json({
+            token_type: 'Bearer',
+            access_token: accessToken,
+            refresh_token: refreshToken,
+            expires_in: expiresIn,
+          });
+        }
+        return HttpResponse.json({
+          error: 'authorization_pending',
+          error_description: 'pending',
+        });
+      }),
+    );
+
+    const open = (await import('open')).default;
+    const config: import('../../config/index.js').GleanOAuthConfig = {
+      baseUrl,
+      issuer,
+      clientId,
+      authorizationEndpoint: deviceAuthorizationEndpoint,
+      tokenEndpoint,
+      authType: 'oauth',
+      codeChallenge,
+      codeChallengeMethod,
+      codeVerifier,
+    };
+    const resultPromise = forceAuthorize(config);
+    await vi.runAllTimersAsync();
+    const tokens = await resultPromise;
+
+    expect(open).toHaveBeenCalledWith(verificationUri);
+    expect(tokens).not.toBeNull();
+    expect(tokens?.accessToken).toBe(accessToken);
+    expect(tokens?.refreshToken).toBe(refreshToken);
+    expect(tokens?.expiresAt).toBeInstanceOf(Date);
+    // Tokens file was written and contains correct data
+    const tokensFile = path.join(
+      process.env.XDG_STATE_HOME!,
+      'glean',
+      'tokens.json',
+    );
+    expect(fs.existsSync(tokensFile)).toBe(true);
+    const fileContent = JSON.parse(fs.readFileSync(tokensFile, 'utf-8'));
+    expect(fileContent.accessToken).toBe(accessToken);
+    expect(fileContent.refreshToken).toBe(refreshToken);
+    expect(new Date(fileContent.expiresAt)).toEqual(tokens!.expiresAt);
+  });
+
   describe('AbortController integration', () => {
     // Common test constants
     const baseUrl = 'https://glean.example.com';

--- a/packages/mcp-server-utils/src/test/auth/authorize.test.ts
+++ b/packages/mcp-server-utils/src/test/auth/authorize.test.ts
@@ -634,6 +634,9 @@ describe('authorize (device flow)', () => {
   });
 
   it('should complete the device flow with PKCE (OneLogin) and save tokens', async () => {
+    vi.useFakeTimers({
+      now: new Date('2025-07-23T20:31:33.340Z'),
+    });
     const baseUrl = 'https://glean.example.com';
     const issuer = 'https://example.onelogin.com';
     const clientId = 'client-123';
@@ -717,10 +720,13 @@ describe('authorize (device flow)', () => {
     const tokens = await resultPromise;
 
     expect(open).toHaveBeenCalledWith(verificationUri);
-    expect(tokens).not.toBeNull();
-    expect(tokens?.accessToken).toBe(accessToken);
-    expect(tokens?.refreshToken).toBe(refreshToken);
-    expect(tokens?.expiresAt).toBeInstanceOf(Date);
+    expect(tokens).toMatchInlineSnapshot(`
+      Tokens {
+        "accessToken": "access-token-123",
+        "expiresAt": 2025-07-23T20:51:15.925Z,
+        "refreshToken": "refresh-token-456",
+      }
+    `);
     // Tokens file was written and contains correct data
     const tokensFile = path.join(
       process.env.XDG_STATE_HOME!,
@@ -729,8 +735,13 @@ describe('authorize (device flow)', () => {
     );
     expect(fs.existsSync(tokensFile)).toBe(true);
     const fileContent = JSON.parse(fs.readFileSync(tokensFile, 'utf-8'));
-    expect(fileContent.accessToken).toBe(accessToken);
-    expect(fileContent.refreshToken).toBe(refreshToken);
+    expect(fileContent).toMatchInlineSnapshot(`
+      {
+        "accessToken": "access-token-123",
+        "expiresAt": "2025-07-23T20:51:15.925Z",
+        "refreshToken": "refresh-token-456",
+      }
+    `);
     expect(new Date(fileContent.expiresAt)).toEqual(tokens!.expiresAt);
   });
 

--- a/packages/mcp-server-utils/src/util/pkce.ts
+++ b/packages/mcp-server-utils/src/util/pkce.ts
@@ -1,0 +1,55 @@
+import crypto from 'node:crypto';
+
+/**
+ * A PKCE pair: codeVerifier and codeChallenge.
+ */
+export type PkcePair = {
+  codeVerifier: string;
+  codeChallenge: string;
+};
+
+/**
+ * Generates a random PKCE code verifier (43-128 characters).
+ * @returns {string} The code verifier.
+ */
+export function generateCodeVerifier(length = 128): string {
+  // Allowed chars: ALPHA / DIGIT / '-' / '.' / '_' / '~'
+  // We'll use base64url encoding of random bytes, then trim to length
+  const bytes = crypto.randomBytes(length);
+  return base64UrlEncode(bytes).slice(0, length);
+}
+
+/**
+ * Generates a PKCE code challenge from a code verifier.
+ * @param {string} codeVerifier - The code verifier.
+ * @returns {Promise<string>} The code challenge (base64url-encoded SHA256 hash).
+ */
+export async function generateCodeChallenge(
+  codeVerifier: string,
+): Promise<string> {
+  const hash = crypto.createHash('sha256').update(codeVerifier).digest();
+  return base64UrlEncode(hash);
+}
+
+/**
+ * Helper to generate both code verifier and code challenge.
+ * @returns {Promise<PkcePair>}
+ */
+export async function generatePkcePair(): Promise<PkcePair> {
+  const codeVerifier = generateCodeVerifier();
+  const codeChallenge = await generateCodeChallenge(codeVerifier);
+  return { codeVerifier, codeChallenge };
+}
+
+/**
+ * Base64-url encodes a buffer (RFC 4648 §5).
+ * @param {Buffer} buffer
+ * @returns {string}
+ */
+export function base64UrlEncode(buffer: Buffer): string {
+  return buffer
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,7 +49,7 @@ importers:
         version: 1.6.3(@algolia/client-search@5.28.0)(@types/node@24.0.13)(postcss@8.5.6)(search-insights@2.17.3)(typescript@5.8.3)
       vitest:
         specifier: ^3.2.3
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.13)(jiti@2.5.1)(msw@2.10.2(@types/node@24.0.13)(typescript@5.8.3))(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.13)(jiti@2.5.1)(msw@2.10.2(@types/node@24.0.13)(typescript@5.8.3))(tsx@4.20.3)(yaml@2.8.0)
 
   packages/configure-mcp-server:
     dependencies:
@@ -135,12 +135,15 @@ importers:
       sort-package-json:
         specifier: ^3.4.0
         version: 3.4.0
+      tsx:
+        specifier: ^4.20.3
+        version: 4.20.3
       typescript:
         specifier: ^5.8.2
         version: 5.8.3
       vitest:
         specifier: ^3.2.3
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.13)(jiti@2.5.1)(msw@2.10.2(@types/node@24.0.13)(typescript@5.8.3))(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.13)(jiti@2.5.1)(msw@2.10.2(@types/node@24.0.13)(typescript@5.8.3))(tsx@4.20.3)(yaml@2.8.0)
 
   packages/local-mcp-server:
     dependencies:
@@ -228,7 +231,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.2.3
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.13)(jiti@2.5.1)(msw@2.10.2(@types/node@24.0.13)(typescript@5.8.3))(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.13)(jiti@2.5.1)(msw@2.10.2(@types/node@24.0.13)(typescript@5.8.3))(tsx@4.20.3)(yaml@2.8.0)
 
   packages/mcp-server-utils:
     dependencies:
@@ -307,7 +310,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.2.3
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.13)(jiti@2.5.1)(msw@2.10.2(@types/node@24.0.13)(typescript@5.8.3))(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.13)(jiti@2.5.1)(msw@2.10.2(@types/node@24.0.13)(typescript@5.8.3))(tsx@4.20.3)(yaml@2.8.0)
 
   packages/mcp-test-utils:
     devDependencies:
@@ -2398,6 +2401,9 @@ packages:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
 
+  get-tsconfig@4.10.1:
+    resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
+
   get-uri@6.0.5:
     resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
     engines: {node: '>= 14'}
@@ -3545,6 +3551,9 @@ packages:
     resolution: {integrity: sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==}
     engines: {node: '>= 12'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   resolve@1.22.10:
     resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
     engines: {node: '>= 0.4'}
@@ -3950,6 +3959,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.20.3:
+    resolution: {integrity: sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -5374,14 +5388,14 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(msw@2.10.2(@types/node@24.0.13)(typescript@5.8.3))(vite@6.3.5(@types/node@24.0.13)(jiti@2.5.1)(yaml@2.8.0))':
+  '@vitest/mocker@3.2.4(msw@2.10.2(@types/node@24.0.13)(typescript@5.8.3))(vite@6.3.5(@types/node@24.0.13)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       msw: 2.10.2(@types/node@24.0.13)(typescript@5.8.3)
-      vite: 6.3.5(@types/node@24.0.13)(jiti@2.5.1)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@24.0.13)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.8.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -6564,6 +6578,10 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
+
+  get-tsconfig@4.10.1:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   get-uri@6.0.5:
     dependencies:
@@ -7836,6 +7854,8 @@ snapshots:
     dependencies:
       path-root: 0.1.1
 
+  resolve-pkg-maps@1.0.0: {}
+
   resolve@1.22.10:
     dependencies:
       is-core-module: 2.16.1
@@ -8318,6 +8338,13 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.20.3:
+    dependencies:
+      esbuild: 0.25.5
+      get-tsconfig: 4.10.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -8468,13 +8495,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@3.2.4(@types/node@24.0.13)(jiti@2.5.1)(yaml@2.8.0):
+  vite-node@3.2.4(@types/node@24.0.13)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.5(@types/node@24.0.13)(jiti@2.5.1)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@24.0.13)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -8498,7 +8525,7 @@ snapshots:
       '@types/node': 24.0.13
       fsevents: 2.3.3
 
-  vite@6.3.5(@types/node@24.0.13)(jiti@2.5.1)(yaml@2.8.0):
+  vite@6.3.5(@types/node@24.0.13)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.5
       fdir: 6.4.6(picomatch@4.0.2)
@@ -8510,6 +8537,7 @@ snapshots:
       '@types/node': 24.0.13
       fsevents: 2.3.3
       jiti: 2.5.1
+      tsx: 4.20.3
       yaml: 2.8.0
 
   vitepress@1.6.3(@algolia/client-search@5.28.0)(@types/node@24.0.13)(postcss@8.5.6)(search-insights@2.17.3)(typescript@5.8.3):
@@ -8561,11 +8589,11 @@ snapshots:
       - typescript
       - universal-cookie
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.0.13)(jiti@2.5.1)(msw@2.10.2(@types/node@24.0.13)(typescript@5.8.3))(yaml@2.8.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.0.13)(jiti@2.5.1)(msw@2.10.2(@types/node@24.0.13)(typescript@5.8.3))(tsx@4.20.3)(yaml@2.8.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.10.2(@types/node@24.0.13)(typescript@5.8.3))(vite@6.3.5(@types/node@24.0.13)(jiti@2.5.1)(yaml@2.8.0))
+      '@vitest/mocker': 3.2.4(msw@2.10.2(@types/node@24.0.13)(typescript@5.8.3))(vite@6.3.5(@types/node@24.0.13)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.8.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -8583,8 +8611,8 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.3.5(@types/node@24.0.13)(jiti@2.5.1)(yaml@2.8.0)
-      vite-node: 3.2.4(@types/node@24.0.13)(jiti@2.5.1)(yaml@2.8.0)
+      vite: 6.3.5(@types/node@24.0.13)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.8.0)
+      vite-node: 3.2.4(@types/node@24.0.13)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.8.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12


### PR DESCRIPTION
## Description

* Added PKCE support for OAuth device flow specifically for `onelogin.com`, including changes to the `GleanOAuthConfig` to incorporate `codeVerifier`, `codeChallenge`, and `codeChallengeMethod` fields. Implemented utility functions for generating PKCE pairs, alongside updates in the authentication logic to support these changes.

* New script added in the `package.json` for easier execution (`go` command using `tsx`). 

## Related Issue

<!-- Link to the issue this PR addresses using the syntax: Fixes #issue_number -->

Fixes #

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

## Type of Change

<!-- Please check the options that are relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):

## How Has This Been Tested?

<!-- Please describe the tests you've added or the tests that verify this change works correctly -->

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Other (please describe):

## Checklist

<!-- Please check all that apply -->

- [ ] My code follows the code style of this project
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have checked for potential breaking changes and addressed them

## Screenshots (if appropriate)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Any other information that is important to this PR -->
