### PR TITLE
fix: CVE-2025-7783

### DIFF
--- a/packages/configure-mcp-server/package.json
+++ b/packages/configure-mcp-server/package.json
@@ -67,6 +67,7 @@
     "console-test-helpers": "^0.3.3",
     "eslint": "^9.30.1",
     "fixturify": "^3.0.0",
+    "form-data": "^4.0.4",
     "fs-extra": "^11.3.0",
     "globals": "^16.3.0",
     "msw": "^2.10.2",

--- a/packages/local-mcp-server/package.json
+++ b/packages/local-mcp-server/package.json
@@ -71,6 +71,7 @@
     "console-test-helpers": "^0.3.3",
     "eslint": "^9.30.1",
     "fixturify": "^3.0.0",
+    "form-data": "^4.0.4",
     "fs-extra": "^11.3.0",
     "globals": "^16.3.0",
     "msw": "^2.10.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       fixturify:
         specifier: ^3.0.0
         version: 3.0.0
+      form-data:
+        specifier: ^4.0.4
+        version: 4.0.4
       fs-extra:
         specifier: ^11.3.0
         version: 11.3.0
@@ -199,6 +202,9 @@ importers:
       fixturify:
         specifier: ^3.0.0
         version: 3.0.0
+      form-data:
+        specifier: ^4.0.4
+        version: 4.0.4
       fs-extra:
         specifier: ^11.3.0
         version: 11.3.0
@@ -2257,8 +2263,8 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data@4.0.3:
-    resolution: {integrity: sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==}
+  form-data@4.0.4:
+    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
 
   forwarded@0.2.0:
@@ -5113,7 +5119,7 @@ snapshots:
   '@types/node-fetch@2.6.12':
     dependencies:
       '@types/node': 24.0.13
-      form-data: 4.0.3
+      form-data: 4.0.4
 
   '@types/node@24.0.13':
     dependencies:
@@ -6353,7 +6359,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data@4.0.3:
+  form-data@4.0.4:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8


### PR DESCRIPTION
Resolved by bumping form-data.  Note this is only a dev dependency.  No impact to users.

https://github.com/gleanwork/mcp-server/security/dependabot/18
