### PR TITLE
fix: Support Azure

### DIFF
--- a/packages/configure-mcp-server/package.json
+++ b/packages/configure-mcp-server/package.json
@@ -45,7 +45,7 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@gleanwork/connect-mcp-server": "^0.2.3",
+    "@gleanwork/connect-mcp-server": "^0.2.4",
     "@gleanwork/local-mcp-server": "workspace:*",
     "@gleanwork/mcp-server-utils": "workspace:*",
     "dotenv": "^17.2.0",

--- a/packages/configure-mcp-server/src/test/cli.test.ts
+++ b/packages/configure-mcp-server/src/test/cli.test.ts
@@ -1054,7 +1054,7 @@ Error configuring client: API token is required. Please provide a token with the
               "command": "npx",
               "args": [
                 "-y",
-                "@gleanwork/connect-mcp-server@0.2.3",
+                "@gleanwork/connect-mcp-server@0.2.4",
                 "https://test-domain-be.glean.com/mcp/default/sse",
                 "--header",
                 "Authorization:\${AUTH_HEADER}"
@@ -1125,7 +1125,7 @@ Error configuring client: API token is required. Please provide a token with the
                 "command": "npx",
                 "args": [
                   "-y",
-                  "@gleanwork/connect-mcp-server@0.2.3",
+                  "@gleanwork/connect-mcp-server@0.2.4",
                   "https://test-domain-be.glean.com/mcp/default/sse",
                   "--header",
                   "Authorization:\${AUTH_HEADER}"
@@ -1670,7 +1670,7 @@ Error configuring client: API token is required. Please provide a token with the
               "command": "npx",
               "args": [
                 "-y",
-                "@gleanwork/connect-mcp-server@0.2.3",
+                "@gleanwork/connect-mcp-server@0.2.4",
                 "https://test-domain-be.glean.com/mcp/default/sse",
                 "--header",
                 "Authorization:\${AUTH_HEADER}"
@@ -1726,7 +1726,7 @@ Error configuring client: API token is required. Please provide a token with the
               "command": "npx",
               "args": [
                 "-y",
-                "@gleanwork/connect-mcp-server@0.2.3",
+                "@gleanwork/connect-mcp-server@0.2.4",
                 "https://test-domain-be.glean.com/mcp/default/sse",
                 "--header",
                 "Authorization:\${AUTH_HEADER}"
@@ -1783,7 +1783,7 @@ Error configuring client: API token is required. Please provide a token with the
               "command": "npx",
               "args": [
                 "-y",
-                "@gleanwork/connect-mcp-server@0.2.3",
+                "@gleanwork/connect-mcp-server@0.2.4",
                 "https://test-domain-be.glean.com/mcp/agents/sse",
                 "--header",
                 "Authorization:\${AUTH_HEADER}"
@@ -1869,7 +1869,7 @@ Error configuring client: API token is required. Please provide a token with the
             "glean": {
               "args": [
                 "-y",
-                "@gleanwork/connect-mcp-server@0.2.3",
+                "@gleanwork/connect-mcp-server@0.2.4",
                 "https://test-instance-be.glean.com/mcp/default/sse",
                 "--header",
                 "Authorization:\${AUTH_HEADER}",
@@ -1926,7 +1926,7 @@ Error configuring client: API token is required. Please provide a token with the
             "glean": {
               "args": [
                 "-y",
-                "@gleanwork/connect-mcp-server@0.2.3",
+                "@gleanwork/connect-mcp-server@0.2.4",
                 "https://env-instance-be.glean.com/mcp/default/sse",
                 "--header",
                 "Authorization:\${AUTH_HEADER}",
@@ -1960,7 +1960,7 @@ Error configuring client: API token is required. Please provide a token with the
             "glean": {
               "args": [
                 "-y",
-                "@gleanwork/connect-mcp-server@0.2.3",
+                "@gleanwork/connect-mcp-server@0.2.4",
                 "https://process-env-instance-be.glean.com/mcp/default/sse",
                 "--header",
                 "Authorization:\${AUTH_HEADER}",
@@ -2007,7 +2007,7 @@ Error configuring client: API token is required. Please provide a token with the
             "glean": {
               "args": [
                 "-y",
-                "@gleanwork/connect-mcp-server@0.2.3",
+                "@gleanwork/connect-mcp-server@0.2.4",
                 "https://flag-instance-be.glean.com/mcp/default/sse",
                 "--header",
                 "Authorization:\${AUTH_HEADER}",
@@ -2100,7 +2100,7 @@ Error configuring client: API token is required. Please provide a token with the
                 "command": "npx",
                 "args": [
                   "-y",
-                  "@gleanwork/connect-mcp-server@0.2.3",
+                  "@gleanwork/connect-mcp-server@0.2.4",
                   "https://test-domain-be.glean.com/mcp/default/sse",
                   "--header",
                   "Authorization:\${AUTH_HEADER}"
@@ -2171,7 +2171,7 @@ Error configuring client: API token is required. Please provide a token with the
                 "command": "npx",
                 "args": [
                   "-y",
-                  "@gleanwork/connect-mcp-server@0.2.3",
+                  "@gleanwork/connect-mcp-server@0.2.4",
                   "https://test-domain-be.glean.com/mcp/default/sse",
                   "--header",
                   "Authorization:\${AUTH_HEADER}"
@@ -2240,7 +2240,7 @@ Error configuring client: API token is required. Please provide a token with the
                 "command": "npx",
                 "args": [
                   "-y",
-                  "@gleanwork/connect-mcp-server@0.2.3",
+                  "@gleanwork/connect-mcp-server@0.2.4",
                   "https://test-domain-be.glean.com/mcp/default/sse",
                   "--header",
                   "Authorization:\${AUTH_HEADER}"
@@ -2302,7 +2302,7 @@ Error configuring client: API token is required. Please provide a token with the
               "glean": {
                 "args": [
                   "-y",
-                  "@gleanwork/connect-mcp-server@0.2.3",
+                  "@gleanwork/connect-mcp-server@0.2.4",
                   "https://test-domain-be.glean.com/mcp/default/sse",
                   "--header",
                   "Authorization:\${AUTH_HEADER}",
@@ -2316,7 +2316,7 @@ Error configuring client: API token is required. Please provide a token with the
               "glean_agents": {
                 "args": [
                   "-y",
-                  "@gleanwork/connect-mcp-server@0.2.3",
+                  "@gleanwork/connect-mcp-server@0.2.4",
                   "https://test-domain-be.glean.com/mcp/agents/sse",
                   "--header",
                   "Authorization:\${AUTH_HEADER}",
@@ -2385,7 +2385,7 @@ Error configuring client: API token is required. Please provide a token with the
                 "command": "npx",
                 "args": [
                   "-y",
-                  "@gleanwork/connect-mcp-server@0.2.3",
+                  "@gleanwork/connect-mcp-server@0.2.4",
                   "https://test-domain-be.glean.com/mcp/default/sse",
                   "--header",
                   "Authorization:\${AUTH_HEADER}"
@@ -2458,7 +2458,7 @@ Error configuring client: API token is required. Please provide a token with the
                 "command": "npx",
                 "args": [
                   "-y",
-                  "@gleanwork/connect-mcp-server@0.2.3",
+                  "@gleanwork/connect-mcp-server@0.2.4",
                   "https://test-domain-be.glean.com/mcp/default/sse",
                   "--header",
                   "Authorization:\${AUTH_HEADER}"
@@ -2527,7 +2527,7 @@ Error configuring client: API token is required. Please provide a token with the
                 "command": "npx",
                 "args": [
                   "-y",
-                  "@gleanwork/connect-mcp-server@0.2.3",
+                  "@gleanwork/connect-mcp-server@0.2.4",
                   "https://test-domain-be.glean.com/mcp/default/sse",
                   "--header",
                   "Authorization:\${AUTH_HEADER}"
@@ -2589,7 +2589,7 @@ Error configuring client: API token is required. Please provide a token with the
               "glean": {
                 "args": [
                   "-y",
-                  "@gleanwork/connect-mcp-server@0.2.3",
+                  "@gleanwork/connect-mcp-server@0.2.4",
                   "https://test-domain-be.glean.com/mcp/default/sse",
                   "--header",
                   "Authorization:\${AUTH_HEADER}",
@@ -2603,7 +2603,7 @@ Error configuring client: API token is required. Please provide a token with the
               "glean_agents": {
                 "args": [
                   "-y",
-                  "@gleanwork/connect-mcp-server@0.2.3",
+                  "@gleanwork/connect-mcp-server@0.2.4",
                   "https://test-domain-be.glean.com/mcp/agents/sse",
                   "--header",
                   "Authorization:\${AUTH_HEADER}",
@@ -2673,7 +2673,7 @@ Error configuring client: API token is required. Please provide a token with the
                 "command": "npx",
                 "args": [
                   "-y",
-                  "@gleanwork/connect-mcp-server@0.2.3",
+                  "@gleanwork/connect-mcp-server@0.2.4",
                   "https://test-domain-be.glean.com/mcp/default/sse",
                   "--header",
                   "Authorization:\${AUTH_HEADER}"
@@ -2745,7 +2745,7 @@ Error configuring client: API token is required. Please provide a token with the
                 "command": "npx",
                 "args": [
                   "-y",
-                  "@gleanwork/connect-mcp-server@0.2.3",
+                  "@gleanwork/connect-mcp-server@0.2.4",
                   "https://test-domain-be.glean.com/mcp/default/sse",
                   "--header",
                   "Authorization:\${AUTH_HEADER}"
@@ -2815,7 +2815,7 @@ Error configuring client: API token is required. Please provide a token with the
                 "command": "npx",
                 "args": [
                   "-y",
-                  "@gleanwork/connect-mcp-server@0.2.3",
+                  "@gleanwork/connect-mcp-server@0.2.4",
                   "https://test-domain-be.glean.com/mcp/default/sse",
                   "--header",
                   "Authorization:\${AUTH_HEADER}"
@@ -2877,7 +2877,7 @@ Error configuring client: API token is required. Please provide a token with the
               "glean": {
                 "args": [
                   "-y",
-                  "@gleanwork/connect-mcp-server@0.2.3",
+                  "@gleanwork/connect-mcp-server@0.2.4",
                   "https://test-domain-be.glean.com/mcp/default/sse",
                   "--header",
                   "Authorization:\${AUTH_HEADER}",
@@ -2891,7 +2891,7 @@ Error configuring client: API token is required. Please provide a token with the
               "glean_agents": {
                 "args": [
                   "-y",
-                  "@gleanwork/connect-mcp-server@0.2.3",
+                  "@gleanwork/connect-mcp-server@0.2.4",
                   "https://test-domain-be.glean.com/mcp/agents/sse",
                   "--header",
                   "Authorization:\${AUTH_HEADER}",
@@ -2959,7 +2959,7 @@ Error configuring client: API token is required. Please provide a token with the
               "glean": {
                 "args": [
                   "-y",
-                  "@gleanwork/connect-mcp-server@0.2.3",
+                  "@gleanwork/connect-mcp-server@0.2.4",
                   "https://test-domain-be.glean.com/mcp/default/sse",
                   "--header",
                   "Authorization:\${AUTH_HEADER}",
@@ -3031,7 +3031,7 @@ Error configuring client: API token is required. Please provide a token with the
               "glean": {
                 "args": [
                   "-y",
-                  "@gleanwork/connect-mcp-server@0.2.3",
+                  "@gleanwork/connect-mcp-server@0.2.4",
                   "https://test-domain-be.glean.com/mcp/default/sse",
                   "--header",
                   "Authorization:\${AUTH_HEADER}",
@@ -3120,7 +3120,7 @@ Error configuring client: API token is required. Please provide a token with the
               "glean": {
                 "args": [
                   "-y",
-                  "@gleanwork/connect-mcp-server@0.2.3",
+                  "@gleanwork/connect-mcp-server@0.2.4",
                   "https://test-domain-be.glean.com/mcp/default/sse",
                   "--header",
                   "Authorization:\${AUTH_HEADER}",
@@ -3195,7 +3195,7 @@ Error configuring client: API token is required. Please provide a token with the
               "glean": {
                 "args": [
                   "-y",
-                  "@gleanwork/connect-mcp-server@0.2.3",
+                  "@gleanwork/connect-mcp-server@0.2.4",
                   "https://test-domain-be.glean.com/mcp/default/sse",
                   "--header",
                   "Authorization:\${AUTH_HEADER}",
@@ -3215,7 +3215,7 @@ Error configuring client: API token is required. Please provide a token with the
               "glean_agents": {
                 "args": [
                   "-y",
-                  "@gleanwork/connect-mcp-server@0.2.3",
+                  "@gleanwork/connect-mcp-server@0.2.4",
                   "https://test-domain-be.glean.com/mcp/agents/sse",
                   "--header",
                   "Authorization:\${AUTH_HEADER}",
@@ -3320,7 +3320,7 @@ Error configuring client: API token is required. Please provide a token with the
                 "glean": {
                   "args": [
                     "-y",
-                    "@gleanwork/connect-mcp-server@0.2.3",
+                    "@gleanwork/connect-mcp-server@0.2.4",
                     "https://test-domain-be.glean.com/mcp/default/sse",
                     "--header",
                     "Authorization:\${AUTH_HEADER}",
@@ -3390,7 +3390,7 @@ Error configuring client: API token is required. Please provide a token with the
                 "glean": {
                   "args": [
                     "-y",
-                    "@gleanwork/connect-mcp-server@0.2.3",
+                    "@gleanwork/connect-mcp-server@0.2.4",
                     "https://test-domain-be.glean.com/mcp/default/sse",
                     "--header",
                     "Authorization:\${AUTH_HEADER}",
@@ -3472,7 +3472,7 @@ Error configuring client: API token is required. Please provide a token with the
                   "command": "npx",
                   "args": [
                     "-y",
-                    "@gleanwork/connect-mcp-server@0.2.3",
+                    "@gleanwork/connect-mcp-server@0.2.4",
                     "https://test-domain-be.glean.com/mcp/default/sse",
                     "--header",
                     "Authorization:\${AUTH_HEADER}"
@@ -3542,7 +3542,7 @@ Error configuring client: API token is required. Please provide a token with the
                 "glean": {
                   "args": [
                     "-y",
-                    "@gleanwork/connect-mcp-server@0.2.3",
+                    "@gleanwork/connect-mcp-server@0.2.4",
                     "https://test-domain-be.glean.com/mcp/default/sse",
                     "--header",
                     "Authorization:\${AUTH_HEADER}",
@@ -3556,7 +3556,7 @@ Error configuring client: API token is required. Please provide a token with the
                 "glean_agents": {
                   "args": [
                     "-y",
-                    "@gleanwork/connect-mcp-server@0.2.3",
+                    "@gleanwork/connect-mcp-server@0.2.4",
                     "https://test-domain-be.glean.com/mcp/agents/sse",
                     "--header",
                     "Authorization:\${AUTH_HEADER}",

--- a/packages/configure-mcp-server/src/test/configure.test.ts
+++ b/packages/configure-mcp-server/src/test/configure.test.ts
@@ -221,7 +221,7 @@ describe('configure', () => {
           "glean": {
             "args": [
               "-y",
-              "@gleanwork/connect-mcp-server@0.2.3",
+              "@gleanwork/connect-mcp-server@0.2.4",
               "https://test-instance-be.glean.com/mcp/default/sse",
               "--header",
               "X-Glean-Auth-Type:OAUTH",
@@ -256,7 +256,7 @@ describe('configure', () => {
           "glean_agents": {
             "args": [
               "-y",
-              "@gleanwork/connect-mcp-server@0.2.3",
+              "@gleanwork/connect-mcp-server@0.2.4",
               "https://test-instance-be.glean.com/mcp/agents/sse",
               "--header",
               "X-Glean-Auth-Type:OAUTH",
@@ -287,7 +287,7 @@ describe('configure', () => {
           "glean": {
             "args": [
               "-y",
-              "@gleanwork/connect-mcp-server@0.2.3",
+              "@gleanwork/connect-mcp-server@0.2.4",
               "https://test-instance-be.glean.com/mcp/default/sse",
               "--header",
               "Authorization:\${AUTH_HEADER}",

--- a/packages/configure-mcp-server/src/test/configure/vscode.test.ts
+++ b/packages/configure-mcp-server/src/test/configure/vscode.test.ts
@@ -142,7 +142,7 @@ describe('VS Code MCP Client', () => {
           "glean": {
             "args": [
               "-y",
-              "@gleanwork/connect-mcp-server@0.2.3",
+              "@gleanwork/connect-mcp-server@0.2.4",
               "https://example-instance-be.glean.com/mcp/default/sse",
               "--header",
               "Authorization:\${AUTH_HEADER}",
@@ -176,7 +176,7 @@ describe('VS Code MCP Client', () => {
           "glean_agents": {
             "args": [
               "-y",
-              "@gleanwork/connect-mcp-server@0.2.3",
+              "@gleanwork/connect-mcp-server@0.2.4",
               "https://example-instance-be.glean.com/mcp/agents/sse",
               "--header",
               "Authorization:\${AUTH_HEADER}",

--- a/packages/mcp-server-utils/package.json
+++ b/packages/mcp-server-utils/package.json
@@ -81,7 +81,7 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@gleanwork/connect-mcp-server": "^0.2.3",
+    "@gleanwork/connect-mcp-server": "^0.2.4",
     "dotenv": "^17.2.0",
     "fs-extra": "^11.3.0",
     "open": "^10.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
   packages/configure-mcp-server:
     dependencies:
       '@gleanwork/connect-mcp-server':
-        specifier: ^0.2.3
-        version: 0.2.3
+        specifier: ^0.2.4
+        version: 0.2.4
       '@gleanwork/local-mcp-server':
         specifier: workspace:*
         version: link:../local-mcp-server
@@ -233,8 +233,8 @@ importers:
   packages/mcp-server-utils:
     dependencies:
       '@gleanwork/connect-mcp-server':
-        specifier: ^0.2.3
-        version: 0.2.3
+        specifier: ^0.2.4
+        version: 0.2.4
       dotenv:
         specifier: ^17.2.0
         version: 17.2.0
@@ -838,8 +838,8 @@ packages:
       react-dom:
         optional: true
 
-  '@gleanwork/connect-mcp-server@0.2.3':
-    resolution: {integrity: sha512-de+DfdZNuFr3/4TFAoJfBvKD+8EyjzFBDjrZ9B1a0/lZnSKW5WwY9ueNDeXDo5SNmoofu1Wirrhiy53+qPyWiQ==}
+  '@gleanwork/connect-mcp-server@0.2.4':
+    resolution: {integrity: sha512-9EswjKncBNcAZtWzBJi3oBHVMR5d/75iOHJNFkjvR0Imqrd2coVp/o5LSckyKHYwm/8TeybDbr2KkLISpfNRag==}
     hasBin: true
 
   '@humanfs/core@0.19.1':
@@ -4636,7 +4636,7 @@ snapshots:
     dependencies:
       zod: 3.25.67
 
-  '@gleanwork/connect-mcp-server@0.2.3':
+  '@gleanwork/connect-mcp-server@0.2.4':
     dependencies:
       express: 4.21.2
       open: 10.1.2


### PR DESCRIPTION
Bump the mcp-remote fork to include the fix for proper openid configuration discovery.  This is necessary for OAuth authorization servers that:

1. Advertise openid-configuration but not oauth-authorization-server and
2. Have a path component in the URL.

This includes Azure.
