### PR TITLE
fix(configure-mcp-server): Support all platforms for Claude Code

### DIFF
--- a/packages/configure-mcp-server/src/configure/client/claude-code.ts
+++ b/packages/configure-mcp-server/src/configure/client/claude-code.ts
@@ -18,16 +18,7 @@ export const claudeCodeConfigPath: MCPConfigPath = {
 };
 
 function claudeCodePathResolver(homedir: string) {
-  let baseDir: string;
-
-  if (process.env.GLEAN_MCP_CONFIG_DIR) {
-    baseDir = process.env.GLEAN_MCP_CONFIG_DIR;
-  } else if (process.platform === 'darwin') {
-    baseDir = homedir;
-  } else {
-    throw new Error('Unsupported platform for Claude Code');
-  }
-
+  const baseDir = process.env.GLEAN_MCP_CONFIG_DIR || homedir;
   return path.join(baseDir, claudeCodeConfigPath.configFileName);
 }
 


### PR DESCRIPTION
Simplifies claudeCodePathResolver by removing platform-specific logic since Claude Code uses the same config path (~/.claude.json) across all platforms.

- Removes unnecessary platform checks for darwin/linux/win32
- Uses simple fallback: GLEAN_MCP_CONFIG_DIR || homedir
- Maintains backward compatibility with existing tests
- Now supports macOS, Linux, and Windows consistently

See claude-code docs here: https://docs.anthropic.com/en/docs/claude-code/settings

---

The tests all override `GLEAN_MCP_CONFIG_DIR` (and are only *nix anyways) otherwise they would have failed.
