### PR TITLE
docs: fix configure package links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 This monorepo contains packages for Glean's local MCP server. For more details see the READMEs of the individual packages.
 
-- [@gleanwork/configure-mcp-server](https://github.com/gleanwork/mcp-server/tree/main/packages/configure-mcp-server) for configuring the local MCP server with popular MCP clients.
+- [@gleanwork/configure-mcp-server](https://github.com/gleanwork/configure-mcp-server) for configuring the local MCP server with popular MCP clients.
 - [@gleanwork/local-mcp-server](https://github.com/gleanwork/mcp-server/tree/main/packages/local-mcp-server) on running the local MCP server.
 
 ## Contributing

--- a/packages/local-mcp-server/README.md
+++ b/packages/local-mcp-server/README.md
@@ -35,7 +35,7 @@ The Glean MCP Server is a [Model Context Protocol (MCP)](https://modelcontextpro
 
 ## MCP Client Configuration
 
-To configure this MCP server in your MCP client (such as Claude Desktop, Windsurf, Cursor, etc.), run [@gleanwork/configure-mcp-server](https://github.com/gleanwork/mcp-server/tree/main/packages/configure-mcp-server) passing in your client, token and instance.
+To configure this MCP server in your MCP client (such as Claude Desktop, Windsurf, Cursor, etc.), run [@gleanwork/configure-mcp-server](https://github.com/gleanwork/configure-mcp-server) passing in your client, token and instance.
 
 ```bash
 # Configure for Cursor
@@ -45,7 +45,7 @@ npx @gleanwork/configure-mcp-server --client cursor --token your_api_token --ins
 npx @gleanwork/configure-mcp-server --client claude --token your_api_token --instance instance_name
 ```
 
-For more details see: [@gleanwork/configure-mcp-server](https://github.com/gleanwork/mcp-server/tree/main/packages/configure-mcp-server).
+For more details see: [@gleanwork/configure-mcp-server](https://github.com/gleanwork/configure-mcp-server).
 
 ### Manual MCP Configuration
 

--- a/packages/mcp-server-utils/README.md
+++ b/packages/mcp-server-utils/README.md
@@ -1,5 +1,5 @@
 # @gleanwork/mcp-server-utils
 
-This package contains private utilities used by [@gleanwork/configure-mcp-server](/packages/configure-mcp-server/README.md) and [@gleanwork/local-mcp-server](/packages/local-mcp-server/README.md).
+This package contains private utilities used by [@gleanwork/configure-mcp-server](https://github.com/gleanwork/configure-mcp-server) and [@gleanwork/local-mcp-server](/packages/local-mcp-server/README.md).
 
 For more information see the [main repository README](https://github.com/gleanwork/mcp-server/).


### PR DESCRIPTION
## Summary
- fix docs linking to configure-mcp-server package
- link to external configure-mcp-server repo for configuration details

## Testing
- `pnpm lint`
- `pnpm test`

Fix #271 