### PR TITLE
docs: add sandbox-claude.md without shallow clone references

### DIFF
--- a/sandbox-claude.md
+++ b/sandbox-claude.md
@@ -1,0 +1,29 @@
+# AI Coding Assistant Sandbox Context
+
+**Important**: You are running in a Glean AI Coding Assistant sandbox environment.
+
+## Environment Details
+- Working directory: /workspace/repo
+- Ephemeral sandbox - changes are temporary until explicitly saved
+- Full access to repository code and tools
+- Git operations are pre-configured with GPG signing
+- The repository has full git history available
+
+## Glean MCP Integration
+Glean's Model Context Protocol (MCP) server is already running in this sandbox. You can call the MCP tools to pull company-wide context directly from the IDE without opening a browser.
+
+When you need additional background that can likely be found in the company context, prefer these tools:
+- **mcp_glean_company_search** – semantic search across PRs, Slack, Confluence, Gmail, Jira, etc.
+- **mcp_glean_read_documents** – fetch full documents once you know their IDs/URLs from a search result.
+
+Example workflows:
+1. *Historical context for a file*: `mcp_glean_company_search` with the filename or symbol to surface design docs, past incidents, and related Slack threads.
+2. *Debug an error*: paste the stack-trace or log snippet into `mcp_glean_company_search` to locate prior occurrences and fixes.
+
+Best practice: run these searches **before** you start large-scale refactors, code reviews, or debugging sessions so you can ground your work in real organisational knowledge.
+
+## Best Practices
+- Focus on the user's specific request
+- Explain key actions and decisions
+- When making code changes, maintain consistency with existing code style
+- Keep changes minimal and don't over-engineer, unless it makes sense for the user's request.


### PR DESCRIPTION
## Summary
- Added sandbox-claude.md file with AI Coding Assistant sandbox context documentation
- Removed outdated references to shallow clones since repositories now have full git history

## Context
As requested, this PR removes the prompting about shallow clones (`--depth=1`) since full clones are now used instead of shallow clones.

🤖 Generated with [Claude Code](https://claude.ai/code)