### PR TITLE
docs: Add note in local-mcp-server README.md recommending the use of the remote MCP server

### DIFF
--- a/packages/local-mcp-server/README.md
+++ b/packages/local-mcp-server/README.md
@@ -5,6 +5,8 @@
 [![npm version](https://badge.fury.io/js/@gleanwork%2Flocal-mcp-server.svg)](https://badge.fury.io/js/@gleanwork%2Flocal-mcp-server)
 [![License](https://img.shields.io/npm/l/@gleanwork%2Fmcp-server.svg)](https://github.com/gleanwork/mcp-server/blob/main/LICENSE)
 
+> **Note:** We recommend using the [remote MCP server integrated directly in Glean](https://docs.glean.com/administration/platform/mcp/about-glean-mcp-integration) instead of this local MCP server. The remote server provides a more seamless experience with automatic updates, better performance, and simplified configuration. This local MCP server is primarily intended for experimental and testing purposes.
+
 The Glean MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) server that provides seamless integration with Glean's enterprise knowledge.
 
 ## Features


### PR DESCRIPTION
## Description


### Code changes:
* Added a note in the README.md recommending the use of the remote MCP server integrated directly in Glean instead of the local MCP server, highlighting benefits such as automatic updates, better performance, and simplified configuration. This local server is now indicated as primarily for experimental and testing purposes.

## Type of Change

<!-- Please check the options that are relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):
