### PR TITLE
Prefix local MCP tool names and keep legacy aliases

### DIFF
--- a/packages/local-mcp-server/README.md
+++ b/packages/local-mcp-server/README.md
@@ -19,21 +19,23 @@ The Glean MCP Server is a [Model Context Protocol (MCP)](https://modelcontextpro
 
 ## Tools
 
-- ### company_search
+- ### glean_company_search
 
   Search Glean's content index using the Glean Search API. This tool allows you to query Glean's content index with various filtering and configuration options.
 
-- ### chat
+- ### glean_chat
 
   Interact with Glean's AI assistant using the Glean Chat API. This tool allows you to have conversational interactions with Glean's AI, including support for message history, citations, and various configuration options.
 
-- ### people_profile_search
+- ### glean_people_profile_search
 
   Search Glean's People directory to find employee information.
 
-- ### read_documents
+- ### glean_read_documents
 
   Read documents from Glean by providing document IDs or URLs. This tool allows you to retrieve the full content of specific documents for detailed analysis or reference.
+
+For backwards compatibility, legacy tool names (`company_search`, `chat`, `people_profile_search`, and `read_documents`) are still accepted by the server when invoked directly.
 
 ## MCP Client Configuration
 

--- a/packages/local-mcp-server/src/server.ts
+++ b/packages/local-mcp-server/src/server.ts
@@ -6,10 +6,10 @@
  * for communication and implements the MCP specification for tool discovery and execution.
  *
  * The server exposes four tools:
- * 1. company_search - Search across Glean's indexed content
- * 2. people_profile_search - Search for people profiles inside the company
- * 3. chat - Converse with Glean's AI assistant
- * 4. read_documents - Retrieve documents by ID or URL
+ * 1. glean_company_search - Search across Glean's indexed content
+ * 2. glean_people_profile_search - Search for people profiles inside the company
+ * 3. glean_chat - Converse with Glean's AI assistant
+ * 4. glean_read_documents - Retrieve documents by ID or URL
  */
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
@@ -31,11 +31,33 @@ import {
 import { VERSION } from './common/version.js';
 
 export const TOOL_NAMES = {
+  companySearch: 'glean_company_search',
+  peopleProfileSearch: 'glean_people_profile_search',
+  chat: 'glean_chat',
+  readDocuments: 'glean_read_documents',
+};
+
+const LEGACY_TOOL_NAMES = {
   companySearch: 'company_search',
   peopleProfileSearch: 'people_profile_search',
   chat: 'chat',
   readDocuments: 'read_documents',
 };
+
+const TOOL_NAME_ALIASES = new Map<string, string>([
+  [TOOL_NAMES.companySearch, TOOL_NAMES.companySearch],
+  [LEGACY_TOOL_NAMES.companySearch, TOOL_NAMES.companySearch],
+  [TOOL_NAMES.peopleProfileSearch, TOOL_NAMES.peopleProfileSearch],
+  [LEGACY_TOOL_NAMES.peopleProfileSearch, TOOL_NAMES.peopleProfileSearch],
+  [TOOL_NAMES.chat, TOOL_NAMES.chat],
+  [LEGACY_TOOL_NAMES.chat, TOOL_NAMES.chat],
+  [TOOL_NAMES.readDocuments, TOOL_NAMES.readDocuments],
+  [LEGACY_TOOL_NAMES.readDocuments, TOOL_NAMES.readDocuments],
+]);
+
+function normalizeToolName(toolName: string): string {
+  return TOOL_NAME_ALIASES.get(toolName) ?? toolName;
+}
 
 /**
  * MCP server instance configured for Glean's implementation.
@@ -134,7 +156,7 @@ export async function callToolHandler(request: CallToolRequest) {
       throw new Error('Arguments are required');
     }
 
-    switch (request.params.name) {
+    switch (normalizeToolName(request.params.name)) {
       case TOOL_NAMES.companySearch: {
         const args = search.ToolSearchSchema.parse(request.params.arguments);
         const result = await search.search(args);

--- a/packages/local-mcp-server/src/test/server.test.ts
+++ b/packages/local-mcp-server/src/test/server.test.ts
@@ -155,6 +155,31 @@ describe('MCP Server Handlers (integration)', () => {
     );
   });
 
+  it('accepts legacy tool aliases for backwards compatibility', async () => {
+    const req = CallToolRequestSchema.parse({
+      method: 'tools/call',
+      id: '6-legacy',
+      jsonrpc: '2.0',
+      params: {
+        name: 'chat',
+        arguments: { message: 'hello' },
+      },
+    });
+
+    const res = await callToolHandler(req);
+    expect(res).toMatchInlineSnapshot(`
+      {
+        "content": [
+          {
+            "text": "GLEAN_AI (UPDATE): Search company knowledge",
+            "type": "text",
+          },
+        ],
+        "isError": false,
+      }
+    `);
+  });
+
   it('executes people_profile_search with filters only', async () => {
     const req = CallToolRequestSchema.parse({
       method: 'tools/call',


### PR DESCRIPTION
## Summary
- rename published local MCP tool names to provider-prefixed variants:
  - `glean_company_search`
  - `glean_people_profile_search`
  - `glean_chat`
  - `glean_read_documents`
- preserve backwards compatibility by accepting legacy names (`company_search`, `people_profile_search`, `chat`, `read_documents`) in `callToolHandler`
- update local package docs and add a regression test that legacy aliases still execute successfully

## Verification
- `pnpm -C packages/local-mcp-server test src/test/server.test.ts`
- `pnpm -C packages/local-mcp-server exec eslint src/server.ts src/test/server.test.ts`

Closes #254