### PR TITLE
docs: link to Glean CLI as alternative for local usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License](https://img.shields.io/npm/l/@gleanwork%2Fmcp-server.svg)](https://github.com/gleanwork/mcp-server/blob/main/LICENSE)
 
 > [!WARNING]
-> We recommend using the [remote MCP server integrated directly in Glean](https://docs.glean.com/administration/platform/mcp/about) instead of this local MCP server. The remote server provides a more seamless experience with automatic updates, better performance, and simplified configuration. This local MCP server is primarily intended for experimental and testing purposes.
+> We recommend using the [remote MCP server integrated directly in Glean](https://docs.glean.com/administration/platform/mcp/about) instead of this local MCP server. The remote server provides a more seamless experience with automatic updates, better performance, and simplified configuration. For local usage, consider [Glean CLI](https://github.com/gleanwork/glean-cli). This local MCP server is primarily intended for experimental and testing purposes.
 
 This monorepo contains packages for Glean's local MCP server. For more details see the READMEs of the individual packages.
 

--- a/packages/local-mcp-server/README.md
+++ b/packages/local-mcp-server/README.md
@@ -6,7 +6,7 @@
 [![License](https://img.shields.io/npm/l/@gleanwork%2Fmcp-server.svg)](https://github.com/gleanwork/mcp-server/blob/main/LICENSE)
 
 > [!WARNING]
-> We recommend using the [remote MCP server integrated directly in Glean](https://docs.glean.com/administration/platform/mcp/about) instead of this local MCP server. The remote server provides a more seamless experience with automatic updates, better performance, and simplified configuration. This local MCP server is primarily intended for experimental and testing purposes.
+> We recommend using the [remote MCP server integrated directly in Glean](https://docs.glean.com/administration/platform/mcp/about) instead of this local MCP server. The remote server provides a more seamless experience with automatic updates, better performance, and simplified configuration. For local usage, consider [Glean CLI](https://github.com/gleanwork/glean-cli). This local MCP server is primarily intended for experimental and testing purposes.
 
 The Glean MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) server that provides seamless integration with Glean's enterprise knowledge.
 


### PR DESCRIPTION
## Description

Add a reference to [gleanwork/glean-cli](https://github.com/gleanwork/glean-cli) in the warning banner so users who want local tooling have a clear path forward.

## Type of Change

- [x] Documentation update

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly

## Stack
1. https://github.com/gleanwork/mcp-server/pull/349
2. **docs: link to Glean CLI as alternative for local usage** (this PR)
