### PR TITLE
Fix mcp-server-utils package exports

### DIFF
--- a/packages/mcp-server-utils/package.json
+++ b/packages/mcp-server-utils/package.json
@@ -16,10 +16,10 @@
   "author": "Steve Calvert <steve.calvert@glean.com>",
   "type": "module",
   "exports": {
-    "./auth": {
-      "types": "./build/auth/index.d.ts",
-      "import": "./build/auth/index.js",
-      "default": "./build/auth/index.js"
+    ".": {
+      "types": "./build/index.d.ts",
+      "import": "./build/index.js",
+      "default": "./build/index.js"
     },
     "./config": {
       "types": "./build/config/index.d.ts",
@@ -30,21 +30,6 @@
       "types": "./build/common/errors.d.ts",
       "import": "./build/common/errors.js",
       "default": "./build/common/errors.js"
-    },
-    "./tools/chat": {
-      "types": "./build/tools/chat.d.ts",
-      "import": "./build/tools/chat.js",
-      "default": "./build/tools/chat.js"
-    },
-    "./tools/people-profile-search": {
-      "types": "./build/tools/people_profile_search.d.ts",
-      "import": "./build/tools/people_profile_search.js",
-      "default": "./build/tools/people_profile_search.js"
-    },
-    "./tools/search": {
-      "types": "./build/tools/search.d.ts",
-      "import": "./build/tools/search.js",
-      "default": "./build/tools/search.js"
     },
     "./util": {
       "types": "./build/util/index.d.ts",

--- a/packages/mcp-server-utils/src/index.ts
+++ b/packages/mcp-server-utils/src/index.ts
@@ -1,0 +1,6 @@
+export * from './common/errors.js';
+export * from './common/version.js';
+export * from './config/index.js';
+export * from './log/logger.js';
+export * from './util/index.js';
+export * from './xdg/xdg.js';


### PR DESCRIPTION
## Summary
- add a root barrel for @gleanwork/mcp-server-utils so the existing main entrypoint is importable through the package exports map
- remove stale exports for auth and tools modules that are not built or shipped by this package

Fixes #360.

## Verification
- corepack pnpm --filter @gleanwork/mcp-test-utils build
- corepack pnpm --filter @gleanwork/mcp-server-utils build
- corepack pnpm --filter @gleanwork/mcp-server-utils test (67 tests passed)
- npm pack --ignore-scripts after build, clean consumer import of root/config/errors/util/logger succeeded and package exports only listed shipped entrypoints